### PR TITLE
Add encoding/decoding tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@ my_alphabet=selfies_alphabet() # contains all semantically valid SELFIES symbols
 
 - an example of SELFIES in a generative model can be seen in the directory 'VariationalAutoEncoder_with_SELFIES\'. There, SMILES datasets are automatically translated into SELFIES, and used for training of a variational autoencoder (VAE).
 
+### Running Tests
+SELFIES uses `pytest` as its testing framework. All tests can be found in the `tests/` directory.
+
+You can run the test suite for SELFIES from your command line:
+
+```bash
+python setup.py test
+```
+
 ### Python version
 fully tested with Python 3.7.1 on
 - 134.000 molecules at QM9 database (https://www.nature.com/articles/sdata201422)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[aliases]
+test = pytest
+
+[tool:pytest]
+python_files = tests/*.py

--- a/setup.py
+++ b/setup.py
@@ -20,5 +20,11 @@ setuptools.setup(
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
     ],
+    setup_requires = [
+        'pytest-runner'
+    ],
+    tests_require = [
+        'pytest'
+    ]
 )
 

--- a/tests/e2e.py
+++ b/tests/e2e.py
@@ -1,0 +1,81 @@
+import pytest
+import selfies as sf
+
+
+class EndToEndTestCase:
+    def __init__(self, identifier: str, smiles: str, selfies: str = None):
+        self.identifier = identifier
+        self.smiles = smiles
+        self.selfies = selfies
+
+
+test_cases = [
+    # Please use canonical SMILES to create new test cases!
+    EndToEndTestCase(
+        identifier='Pentylamine',
+        smiles='CCCCCN',
+        selfies='[C][C][C][C][C][N]'
+    ),
+    EndToEndTestCase(
+        identifier='Phenylalanine',
+        smiles='N[C@@H](Cc1ccccc1)C(=O)O',
+    ),
+    EndToEndTestCase(
+        identifier='MDMA',
+        smiles='CNC(C)Cc1ccc2c(c1)OCO2',
+    ),
+    EndToEndTestCase(
+        identifier='DEET',
+        smiles='CCN(CC)C(=O)c1cccc(C)c1',
+    ),
+    EndToEndTestCase(
+        identifier='Paracetamol',
+        smiles='CC(=O)Nc1ccc(O)cc1',
+    ),
+    EndToEndTestCase(
+        identifier='Ibuprofen',
+        smiles='CC(C)Cc1ccc(C(C)C(=O)O)cc1',
+    ),
+    EndToEndTestCase(
+        identifier='Afatinib',
+        smiles='CN(C)CC=CC(=O)Nc1cc2c(Nc3ccc(F)c(Cl)c3)ncnc2cc1OC1CCOC1',
+    ),
+    EndToEndTestCase(
+        identifier='Sorafenib',
+        smiles='CNC(=O)c1cc(Oc2ccc(NC(=O)Nc3ccc(Cl)c(C(F)(F)F)c3)cc2)ccn1',
+    ),
+    EndToEndTestCase(
+        identifier='Azulene',
+        smiles='c1ccc2cccc-2cc1',
+    ),
+    EndToEndTestCase(
+        identifier='Chrysene',
+        smiles='c1ccc2c(c1)ccc1c3ccccc3ccc21',
+    ),
+    EndToEndTestCase(
+        identifier='WOJWZDJWEWKCIH-SNCNVHSMSA-N',
+        smiles='Cc1c(C)c(S(=O)(=O)NC(=N)NCCC[C@H](NC(=O)[C@@H]2CCCN2C(=O)[C@H](CCC(=O)NC(c2ccccc2)(c2ccccc2)c2ccccc2)NC'
+               '(=O)[C@H](CC(C)C)NC(=O)[C@H](CCCCNC(=O)OC(C)(C)C)NC(=O)[C@H](C)NC(=O)[C@@H]2CCCN2C(=O)[C@@H]2CCCN2C(=O)'
+               '[C@H](CCCCNC(=O)OC(C)(C)C)NC(=O)[C@H](CCCCNC(=O)OC(C)(C)C)NC(=O)[C@H](COC(C)(C)C)NC(=O)[C@H](CCC(=O)OC('
+               'C)(C)C)NC(=O)[C@H](CCCCNC(=O)OC(C)(C)C)NC(=O)[C@H](CCCNC(=N)NS(=O)(=O)c2c(C)c(C)c3c(c2C)CCC(C)(C)O3)NC('
+               '=O)[C@H](CCC(=O)NC(c2ccccc2)(c2ccccc2)c2ccccc2)NC(=O)[C@H](CCC(=O)NC(c2ccccc2)(c2ccccc2)c2ccccc2)NC(=O)'
+               '[C@@H](NC(=O)[C@H](CCCNC(=N)NS(=O)(=O)c2c(C)c(C)c3c(c2C)CCC(C)(C)O3)NC(=O)[C@H](CCC(=O)NC(c2ccccc2)(c2c'
+               'cccc2)c2ccccc2)NC(=O)[C@H](Cc2cn(C(=O)OC(C)(C)C)cn2)NC(=O)[C@H](CCC(=O)OC(C)(C)C)NC(=O)[C@@H]2CCCN2C(=O'
+               ')[C@H](COC(C)(C)C)NC(=O)[C@H](CC(C)C)NC(=O)[C@H](Cc2ccccc2)NC(=O)[C@H](COC(c2ccccc2)(c2ccccc2)c2ccccc2)'
+               'NC(=O)[C@H](COC(C)(C)C)NC(=O)CNC(=O)OC(C)(C)C)C(C)C)C(=O)O)c(C)c2c1OC(C)(C)CC2',
+    ),
+]
+
+
+@pytest.mark.parametrize("case", test_cases, ids=[tc.identifier for tc in test_cases])
+def test_smiles_to_selfies(case: EndToEndTestCase):
+    if not case.selfies:
+        pytest.skip('Need to add an expected SELFIES result for this molecule!')
+    assert sf.encoder(case.smiles) == case.selfies
+
+
+@pytest.mark.parametrize("case", test_cases, ids=[tc.identifier for tc in test_cases])
+def test_roundtrip_smiles_to_selfies(case: EndToEndTestCase):
+    output_selfies = sf.encoder(case.smiles)
+    roundtrip_smiles = sf.decoder(output_selfies)
+    assert case.smiles == roundtrip_smiles


### PR DESCRIPTION
This adds some simple automated tests for contributors. This will help to verify that new changes do not cause bugs in the library.

There are 2 types of tests added:
1. Encode SMILES to SELFIES and verify expected SELFIES string (only for 1 test case)
2. Encode SMILES to SELFIES to SMILES (all test cases)

New test cases can be added by creating an `EndToEndTestCase` inside `e2e.py` with the SMILES and SELFIES string. If you could hand-compute the expected SELFIES result for the other molecules, that would be greatly appreciated!