### PR TITLE
Add continuous integration to automatically run tests for PRs

### DIFF
--- a/.github/workflows/selfies-package.yml
+++ b/.github/workflows/selfies-package.yml
@@ -1,0 +1,33 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: selfies package
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.5, 3.6, 3.7, 3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pytest
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Test with pytest
+      run: |
+        python setup.py pytest


### PR DESCRIPTION
This adds a configuration to automatically run any unit tests for this repository! This uses Github Actions and is free for public repositories. The configuration is based on a [template ](https://github.com/actions/starter-workflows/blob/master/ci/python-package.yml)from Github.

The tests will be run against Python 3.5, 3.6, 3.7 and 3.8.

Example run: https://github.com/darrenwee/selfies/runs/723196358