### PR TITLE
Aromatic Si and Al support

### DIFF
--- a/selfies/kekulize.py
+++ b/selfies/kekulize.py
@@ -126,8 +126,8 @@ def _kekulize(mol_graph) -> None:
 # key = aromatic SMILES element, value = number of valence electrons
 # Note: wild card '*' not supported currently
 _aromatic_valences = {
-    'b': 3, 'c': 4, 'n': 5, 'p': 5, 'as': 5,
-    'o': 6, 's': 6, 'se': 6, 'te': 6
+    'b': 3, 'al': 3, 'c': 4, 'si': 4, 'n': 5, 'p': 5,
+    'as': 5, 'o': 6, 's': 6, 'se': 6, 'te': 6
 }
 
 

--- a/tests/test_sets/Custom_Cases.txt
+++ b/tests/test_sets/Custom_Cases.txt
@@ -25,3 +25,5 @@ c1cc2c3c(c4cccc(c1)c24)c1c2cccc4cccc(c1c1c5cccc6cccc(c31)c56)c24
 [C]O[C](O[C])c1[c][c][c]nc1C(=O)O[C]
 [Bi++].CC([O-])=O.CC([O-])=O.[c]1ccccc1.[c]1ccccc1.[c]1ccccc1
 CC(C)(C)OC(=O)[13c]1[13c][13c][13c](Br)[13c][13c]1F
+C[Si](C)(C)Oc1cccc(F)[si]1[Si](C)(C)C
+c1ccc(Sc2cccc3c2-c2nc-3nc3c4c(Sc5ccccc5)cccc4c4nc5nc(nc6c7c(Sc8ccccc8)cccc7c(n2)n6[al+]n43)-c2cccc(Sc3ccccc3)c2-5)cc1


### PR DESCRIPTION
Add aromatic support for Si and Al. Update custom tests:
```
C[Si](C)(C)Oc1cccc(F)[si]1[Si](C)(C)C                                           
c1ccc(Sc2cccc3c2-c2nc-3nc3c4c(Sc5ccccc5)cccc4c4nc5nc(nc6c7c(Sc8ccccc8)cccc7c(n2)n6[al+]n43)-c2cccc(Sc3ccccc3)c2-5)cc1
```