### PR TITLE
refactored _parse_selfies

### DIFF
--- a/selfies/decoder.py
+++ b/selfies/decoder.py
@@ -98,31 +98,30 @@ def _parse_selfies(selfies: str) -> Iterable[str]:
     :return: an iterable of the symbols of the SELFIES.
     """
 
-    stack = []
     syntax_err = "malformed SELIFES, misplaced or missing brackets"
+    save = False
 
     for char in selfies:
 
-        if char == "[" and len(stack) == 0:
-            symbol = ""
-            stack.append(char)
-
-        elif char == "]" and len(stack) == 1:
-            stack.pop()
-            if symbol != "nop":  # skip [nop]
-                yield "[" + symbol + "]"
-
-        elif char not in "[]" and len(stack) == 1:
+        if char not in "[]" and save:
             symbol += char
 
+        elif char == "[" and not save:
+            symbol = ""
+            save = True
+
+        elif char == "]" and save:
+            save = False
+            if symbol != "nop":  # skip [nop]
+                yield "[" + symbol + "]"
         else:
             raise ValueError(syntax_err)
 
-    if len(stack) > 0:
+    if save:
         raise ValueError(syntax_err)
 
     while True:  # no more symbols left
-        yield ""
+        yield ''
 
 
 def _parse_selfies_symbols(selfies_symbols: List[str]) -> Iterable[str]:

--- a/selfies/decoder.py
+++ b/selfies/decoder.py
@@ -90,33 +90,39 @@ def decoder(selfies: str,
 
 def _parse_selfies(selfies: str) -> Iterable[str]:
     """Parses a SELFIES into its symbols.
-
     A generator, which parses a SELFIES and yields its symbols
     one-by-one. When no symbols are left in the SELFIES, the empty
     string is infinitely yielded. As a precondition, the input SELFIES contains
     no dots, so all symbols are enclosed by square brackets, e.g. [X].
-
     :param selfies: the SElFIES string to be parsed.
     :return: an iterable of the symbols of the SELFIES.
     """
 
-    left_idx = selfies.find('[')
+    stack = []
+    syntax_err = "malformed SELIFES, misplaced or missing brackets"
 
-    while 0 <= left_idx < len(selfies):
-        right_idx = selfies.find(']', left_idx + 1)
+    for char in selfies:
 
-        if (selfies[left_idx] != '[') or (right_idx == -1):
-            raise ValueError("malformed SELIFES, "
-                             "misplaced or missing brackets")
+        if char == "[" and len(stack) == 0:
+            symbol = ""
+            stack.append(char)
 
-        next_symbol = selfies[left_idx: right_idx + 1]
-        left_idx = right_idx + 1
+        elif char == "]" and len(stack) == 1:
+            stack.pop()
+            if symbol != "nop":  # skip [nop]
+                yield "[" + symbol + "]"
 
-        if next_symbol != '[nop]':  # skip [nop]
-            yield next_symbol
+        elif char not in "[]" and len(stack) == 1:
+            symbol += char
+
+        else:
+            raise ValueError(syntax_err)
+
+    if len(stack) > 0:
+        raise ValueError(syntax_err)
 
     while True:  # no more symbols left
-        yield ''
+        yield ""
 
 
 def _parse_selfies_symbols(selfies_symbols: List[str]) -> Iterable[str]:


### PR DESCRIPTION
The _parse_selfies  function  in decoder.py does not catch some syntax error, 

Simple selfies: [A][B][C] 

**case1:  missing "[" at begining**

    selfies = "A][B][C]" 
    the function does not raise error, rather parses, [B], [C] 

**case:2** missing "]" 

    selfies = "[A[B][C]"  
    the function does not raise error, rather parses, [A[B], [C] 

**case-3**: misisng both "[]" at begining 

    selfies=A[B][C]
    the function does not raise error, rather parses, [B], [C] 

**case-4**: extra "[" 
    
    selfies=[A][[[B][C] 
    the function does not raise error, rather parse, [A], [[[B], [C] 

**case-5**: inconsistent spacing rules between symbols 
    
    o Spacing at begining  is parsed  without  error e.g. "   [A][B][C]" 
    o Spacing at the end and middle raises error, e.g., "[A] [B][C]" and "[A][B][C]  "


So, I am proposing a refactoring of the _parse_selfies function. Typically, braket matching can be better handled using a stack. When "[" is encountered, appended into the stack, and "]" is encountered just poped and matched if it is matching brace ("["). The refactored function is also consistent with spacing, it does not allow any spacing between symbols. Though spacing rules can be relaxed, if required. 










