### PR TITLE
fixes parsing of SELFIES with incorrect bracket-ing

### DIFF
--- a/selfies/decoder.py
+++ b/selfies/decoder.py
@@ -114,7 +114,7 @@ def _parse_selfies(selfies: str) -> Iterable[str]:
                              "misplaced or missing brackets")
 
         next_symbol = selfies[left_idx: right_idx + 1]
-        if '[' in next_symbol:
+        if '[' in next_symbol[1:]:
             raise ValueError("malformed SELFIES, "
                              "misplaced or missing brackets")
         left_idx = right_idx + 1

--- a/selfies/decoder.py
+++ b/selfies/decoder.py
@@ -101,15 +101,22 @@ def _parse_selfies(selfies: str) -> Iterable[str]:
     """
 
     left_idx = selfies.find('[')
+    if ']' in selfies[:left_idx]:
+        raise ValueError("malformed SELFIES, "
+                         "misplaced or missing brackets")
+        
 
     while 0 <= left_idx < len(selfies):
         right_idx = selfies.find(']', left_idx + 1)
 
         if (selfies[left_idx] != '[') or (right_idx == -1):
-            raise ValueError("malformed SELIFES, "
+            raise ValueError("malformed SELFIES, "
                              "misplaced or missing brackets")
 
         next_symbol = selfies[left_idx: right_idx + 1]
+        if '[' in next_symbol:
+            raise ValueError("malformed SELFIES, "
+                             "misplaced or missing brackets")
         left_idx = right_idx + 1
 
         if next_symbol != '[nop]':  # skip [nop]


### PR DESCRIPTION
This fixes the errors described in #57 (i.e. missing brackets in selfies string) but with only minimal changes to `_parse_selfies`. The code in #57, while correct (and actually more readable) also involves serious performance regression due to explicit loops over strings. Python is just not very fast...