### PR TITLE
Index symbol customization

### DIFF
--- a/selfies/__init__.py
+++ b/selfies/__init__.py
@@ -36,7 +36,7 @@ __all__ = [
     "set_semantic_constraints",
     "get_preset_index_alphabet",
     "get_index_alphabet",
-    "set_index_alphabet",
+    "update_index_alphabet",
     "len_selfies",
     "split_selfies",
     "get_alphabet_from_selfies",
@@ -57,7 +57,7 @@ from .bond_constraints import (
 from .index_alphabet import (
     get_preset_index_alphabet,
     get_index_alphabet,
-    set_index_alphabet,
+    update_index_alphabet,
 )
 from .decoder import decoder
 from .encoder import encoder

--- a/selfies/__init__.py
+++ b/selfies/__init__.py
@@ -25,7 +25,7 @@ For comments, bug reports or feature ideas, please send an email to
 mario.krenn@utoronto.ca and alan@aspuru.com.
 """
 
-__version__ = "2.0.0.1"
+__version__ = "2.0.0"
 
 __all__ = [
     "encoder",
@@ -34,6 +34,9 @@ __all__ = [
     "get_semantic_robust_alphabet",
     "get_semantic_constraints",
     "set_semantic_constraints",
+    "get_preset_index_alphabet",
+    "get_current_index_alphabet",
+    "set_index_alphabet",
     "len_selfies",
     "split_selfies",
     "get_alphabet_from_selfies",

--- a/selfies/__init__.py
+++ b/selfies/__init__.py
@@ -35,7 +35,7 @@ __all__ = [
     "get_semantic_constraints",
     "set_semantic_constraints",
     "get_preset_index_alphabet",
-    "get_current_index_alphabet",
+    "get_index_alphabet",
     "set_index_alphabet",
     "len_selfies",
     "split_selfies",
@@ -56,7 +56,7 @@ from .bond_constraints import (
 )
 from .index_alphabet import (
     get_preset_index_alphabet,
-    get_current_index_alphabet,
+    get_index_alphabet,
     set_index_alphabet,
 )
 from .decoder import decoder

--- a/selfies/__init__.py
+++ b/selfies/__init__.py
@@ -25,7 +25,7 @@ For comments, bug reports or feature ideas, please send an email to
 mario.krenn@utoronto.ca and alan@aspuru.com.
 """
 
-__version__ = "2.0.0"
+__version__ = "2.0.0.1"
 
 __all__ = [
     "encoder",

--- a/selfies/__init__.py
+++ b/selfies/__init__.py
@@ -51,6 +51,11 @@ from .bond_constraints import (
     get_semantic_robust_alphabet,
     set_semantic_constraints
 )
+from .index_alphabet import (
+    get_preset_index_alphabet,
+    get_current_index_alphabet,
+    set_index_alphabet,
+)
 from .decoder import decoder
 from .encoder import encoder
 from .exceptions import DecoderError, EncoderError

--- a/selfies/bond_constraints.py
+++ b/selfies/bond_constraints.py
@@ -3,9 +3,9 @@ from itertools import product
 from typing import Dict, Set, Union
 
 from selfies.constants import ELEMENTS
-from selfies.index_alphabet import _current_index_alphabet 
+from selfies.index_alphabet import get_current_index_alphabet
 
-INDEX_ALPHABET = tuple(_current_index_alphabet)
+INDEX_ALPHABET = tuple(get_current_index_alphabet())
 
 _DEFAULT_CONSTRAINTS = {
     "H": 1, "F": 1, "Cl": 1, "Br": 1, "I": 1,

--- a/selfies/bond_constraints.py
+++ b/selfies/bond_constraints.py
@@ -5,8 +5,6 @@ from typing import Dict, Set, Union
 from selfies.constants import ELEMENTS
 from selfies.index_alphabet import get_current_index_alphabet
 
-INDEX_ALPHABET = tuple(get_current_index_alphabet())
-
 _DEFAULT_CONSTRAINTS = {
     "H": 1, "F": 1, "Cl": 1, "Br": 1, "I": 1,
     "B": 3, "B+1": 2, "B-1": 4,
@@ -158,6 +156,8 @@ def get_semantic_robust_alphabet() -> Set[str]:
 
     :return: a subset of all SELFIES symbols that are semantically constrained.
     """
+    
+    INDEX_ALPHABET = tuple(get_current_index_alphabet())
 
     alphabet_subset = set()
     bonds = {"": 1, "=": 2, "#": 3}

--- a/selfies/bond_constraints.py
+++ b/selfies/bond_constraints.py
@@ -3,7 +3,7 @@ from itertools import product
 from typing import Dict, Set, Union
 
 from selfies.constants import ELEMENTS
-from selfies.index_alphabet import get_current_index_alphabet
+from selfies.index_alphabet import get_index_alphabet
 
 _DEFAULT_CONSTRAINTS = {
     "H": 1, "F": 1, "Cl": 1, "Br": 1, "I": 1,
@@ -157,7 +157,7 @@ def get_semantic_robust_alphabet() -> Set[str]:
     :return: a subset of all SELFIES symbols that are semantically constrained.
     """
     
-    index_alphabet = tuple(get_current_index_alphabet())
+    index_alphabet = tuple(get_index_alphabet())
 
     alphabet_subset = set()
     bonds = {"": 1, "=": 2, "#": 3}

--- a/selfies/bond_constraints.py
+++ b/selfies/bond_constraints.py
@@ -156,7 +156,7 @@ def get_semantic_robust_alphabet() -> Set[str]:
 
     :return: a subset of all SELFIES symbols that are semantically constrained.
     """
-    
+
     index_alphabet = tuple(get_index_alphabet().values())
 
     alphabet_subset = set()

--- a/selfies/bond_constraints.py
+++ b/selfies/bond_constraints.py
@@ -157,7 +157,7 @@ def get_semantic_robust_alphabet() -> Set[str]:
     :return: a subset of all SELFIES symbols that are semantically constrained.
     """
     
-    INDEX_ALPHABET = tuple(get_current_index_alphabet())
+    index_alphabet = tuple(get_current_index_alphabet())
 
     alphabet_subset = set()
     bonds = {"": 1, "=": 2, "#": 3}
@@ -177,7 +177,7 @@ def get_semantic_robust_alphabet() -> Set[str]:
         alphabet_subset.add("[=Branch{}]".format(i))
         alphabet_subset.add("[#Branch{}]".format(i))
 
-    alphabet_subset.update(INDEX_ALPHABET)
+    alphabet_subset.update(index_alphabet)
 
     return alphabet_subset
 

--- a/selfies/bond_constraints.py
+++ b/selfies/bond_constraints.py
@@ -157,7 +157,7 @@ def get_semantic_robust_alphabet() -> Set[str]:
     :return: a subset of all SELFIES symbols that are semantically constrained.
     """
     
-    index_alphabet = tuple(sorted(get_index_alphabet()))
+    index_alphabet = tuple(get_index_alphabet().values())
 
     alphabet_subset = set()
     bonds = {"": 1, "=": 2, "#": 3}

--- a/selfies/bond_constraints.py
+++ b/selfies/bond_constraints.py
@@ -157,7 +157,7 @@ def get_semantic_robust_alphabet() -> Set[str]:
     :return: a subset of all SELFIES symbols that are semantically constrained.
     """
     
-    index_alphabet = tuple(get_index_alphabet())
+    index_alphabet = tuple(sorted(get_index_alphabet()))
 
     alphabet_subset = set()
     bonds = {"": 1, "=": 2, "#": 3}

--- a/selfies/bond_constraints.py
+++ b/selfies/bond_constraints.py
@@ -5,6 +5,8 @@ from typing import Dict, Set, Union
 from selfies.constants import ELEMENTS
 from selfies.index_alphabet import _current_index_alphabet 
 
+INDEX_ALPHABET = tuple(_current_index_alphabet)
+
 _DEFAULT_CONSTRAINTS = {
     "H": 1, "F": 1, "Cl": 1, "Br": 1, "I": 1,
     "B": 3, "B+1": 2, "B-1": 4,
@@ -175,7 +177,7 @@ def get_semantic_robust_alphabet() -> Set[str]:
         alphabet_subset.add("[=Branch{}]".format(i))
         alphabet_subset.add("[#Branch{}]".format(i))
 
-    alphabet_subset.update(tuple(_current_index_alphabet))
+    alphabet_subset.update(INDEX_ALPHABET)
 
     return alphabet_subset
 

--- a/selfies/bond_constraints.py
+++ b/selfies/bond_constraints.py
@@ -3,7 +3,7 @@ from itertools import product
 from typing import Dict, Set, Union
 
 from selfies.constants import ELEMENTS
-from selfies.index_alphabet import INDEX_ALPHABET
+from selfies.index_alphabet import _current_index_alphabet 
 
 _DEFAULT_CONSTRAINTS = {
     "H": 1, "F": 1, "Cl": 1, "Br": 1, "I": 1,
@@ -175,7 +175,7 @@ def get_semantic_robust_alphabet() -> Set[str]:
         alphabet_subset.add("[=Branch{}]".format(i))
         alphabet_subset.add("[#Branch{}]".format(i))
 
-    alphabet_subset.update(INDEX_ALPHABET)
+    alphabet_subset.update(tuple(_current_index_alphabet))
 
     return alphabet_subset
 

--- a/selfies/decoder.py
+++ b/selfies/decoder.py
@@ -3,7 +3,6 @@ import warnings
 from selfies.compatibility import modernize_symbol
 from selfies.exceptions import DecoderError
 from selfies.grammar_rules import (
-    get_index_from_selfies,
     next_atom_state,
     next_branch_state,
     next_ring_state,
@@ -11,6 +10,7 @@ from selfies.grammar_rules import (
     process_branch_symbol,
     process_ring_symbol
 )
+from selfies.index_alphabet import get_index_from_selfies
 from selfies.mol_graph import MolecularGraph
 from selfies.utils.selfies_utils import split_selfies
 from selfies.utils.smiles_utils import mol_to_smiles

--- a/selfies/encoder.py
+++ b/selfies/encoder.py
@@ -1,5 +1,5 @@
 from selfies.exceptions import EncoderError, SMILESParserError
-from selfies.grammar_rules import get_selfies_from_index
+from selfies.index_alphabet import get_selfies_from_index
 from selfies.utils.linked_list import SinglyLinkedList
 from selfies.utils.smiles_utils import (
     atom_to_smiles,

--- a/selfies/grammar_rules.py
+++ b/selfies/grammar_rules.py
@@ -13,8 +13,6 @@ from selfies.index_alphabet import get_current_index_alphabet
 INDEX_ALPHABET = tuple(get_current_index_alphabet())
 INDEX_CODE = {c: i for i, c in enumerate(INDEX_ALPHABET)}
 
-print(INDEX_ALPHABET)
-
 from selfies.mol_graph import Atom
 from selfies.utils.smiles_utils import smiles_to_bond
 

--- a/selfies/grammar_rules.py
+++ b/selfies/grammar_rules.py
@@ -13,6 +13,8 @@ from selfies.index_alphabet import get_current_index_alphabet
 INDEX_ALPHABET = tuple(get_current_index_alphabet())
 INDEX_CODE = {c: i for i, c in enumerate(INDEX_ALPHABET)}
 
+print(INDEX_ALPHABET)
+
 from selfies.mol_graph import Atom
 from selfies.utils.smiles_utils import smiles_to_bond
 

--- a/selfies/grammar_rules.py
+++ b/selfies/grammar_rules.py
@@ -7,9 +7,7 @@ from selfies.constants import (
     ELEMENTS,
     ORGANIC_SUBSET
 )
-
 from selfies.index_alphabet import get_current_index_alphabet
-
 from selfies.mol_graph import Atom
 from selfies.utils.smiles_utils import smiles_to_bond
 

--- a/selfies/grammar_rules.py
+++ b/selfies/grammar_rules.py
@@ -7,7 +7,7 @@ from selfies.constants import (
     ELEMENTS,
     ORGANIC_SUBSET
 )
-from selfies.index_alphabet import get_current_index_alphabet
+from selfies.index_alphabet import get_index_alphabet
 from selfies.mol_graph import Atom
 from selfies.utils.smiles_utils import smiles_to_bond
 
@@ -77,7 +77,7 @@ def next_ring_state(
 
 
 def get_index_from_selfies(*symbols: List[str]) -> int:
-    index_alphabet = tuple(get_current_index_alphabet())
+    index_alphabet = tuple(get_index_alphabet())
     index_code = {c: i for i, c in enumerate(index_alphabet)}
     index = 0
     for i, c in enumerate(reversed(symbols)):
@@ -87,7 +87,7 @@ def get_index_from_selfies(*symbols: List[str]) -> int:
 
 def get_selfies_from_index(index: int) -> List[str]:
     
-    index_alphabet = tuple(get_current_index_alphabet())
+    index_alphabet = tuple(get_index_alphabet())
     
     if index < 0:
         raise IndexError()

--- a/selfies/grammar_rules.py
+++ b/selfies/grammar_rules.py
@@ -9,9 +9,11 @@ from selfies.constants import (
 )
 
 from selfies.index_alphabet import (
-    INDEX_ALPHABET,
-    INDEX_CODE
+    _current_index_alphabet 
 )
+
+INDEX_ALPHABET = tuple(_current_index_alphabet)
+INDEX_CODE = {c: i for i, c in enumerate(INDEX_ALPHABET)}
 
 from selfies.mol_graph import Atom
 from selfies.utils.smiles_utils import smiles_to_bond

--- a/selfies/grammar_rules.py
+++ b/selfies/grammar_rules.py
@@ -7,7 +7,6 @@ from selfies.constants import (
     ELEMENTS,
     ORGANIC_SUBSET
 )
-from selfies.index_alphabet import get_index_alphabet
 from selfies.mol_graph import Atom
 from selfies.utils.smiles_utils import smiles_to_bond
 
@@ -74,32 +73,6 @@ def next_ring_state(
     bonds_left = state - bond_order
     next_state = None if (bonds_left == 0) else bonds_left
     return bond_order, next_state
-
-
-def get_index_from_selfies(*symbols: List[str]) -> int:
-    index_alphabet = tuple(get_index_alphabet())
-    index_code = {c: i for i, c in enumerate(index_alphabet)}
-    index = 0
-    for i, c in enumerate(reversed(symbols)):
-        index += index_code.get(c, 0) * (len(index_code) ** i)
-    return index
-
-
-def get_selfies_from_index(index: int) -> List[str]:
-    
-    index_alphabet = tuple(get_index_alphabet())
-    
-    if index < 0:
-        raise IndexError()
-    elif index == 0:
-        return [index_alphabet[0]]
-
-    symbols = []
-    base = len(index_alphabet)
-    while index:
-        symbols.append(index_alphabet[index % base])
-        index //= base
-    return symbols[::-1]
 
 
 # =============================================================================

--- a/selfies/grammar_rules.py
+++ b/selfies/grammar_rules.py
@@ -1,7 +1,7 @@
 import functools
 import itertools
 import re
-from typing import Any, List, Optional, Tuple
+from typing import Any, Optional, Tuple
 
 from selfies.constants import (
     ELEMENTS,

--- a/selfies/grammar_rules.py
+++ b/selfies/grammar_rules.py
@@ -77,27 +77,27 @@ def next_ring_state(
 
 
 def get_index_from_selfies(*symbols: List[str]) -> int:
-    INDEX_ALPHABET = tuple(get_current_index_alphabet())
-    INDEX_CODE = {c: i for i, c in enumerate(INDEX_ALPHABET)}
+    index_alphabet = tuple(get_current_index_alphabet())
+    index_code = {c: i for i, c in enumerate(index_alphabet)}
     index = 0
     for i, c in enumerate(reversed(symbols)):
-        index += INDEX_CODE.get(c, 0) * (len(INDEX_CODE) ** i)
+        index += index_code.get(c, 0) * (len(index_code) ** i)
     return index
 
 
 def get_selfies_from_index(index: int) -> List[str]:
     
-    INDEX_ALPHABET = tuple(get_current_index_alphabet())
+    index_alphabet = tuple(get_current_index_alphabet())
     
     if index < 0:
         raise IndexError()
     elif index == 0:
-        return [INDEX_ALPHABET[0]]
+        return [index_alphabet[0]]
 
     symbols = []
-    base = len(INDEX_ALPHABET)
+    base = len(index_alphabet)
     while index:
-        symbols.append(INDEX_ALPHABET[index % base])
+        symbols.append(index_alphabet[index % base])
         index //= base
     return symbols[::-1]
 

--- a/selfies/grammar_rules.py
+++ b/selfies/grammar_rules.py
@@ -8,11 +8,9 @@ from selfies.constants import (
     ORGANIC_SUBSET
 )
 
-from selfies.index_alphabet import (
-    _current_index_alphabet 
-)
+from selfies.index_alphabet import get_current_index_alphabet
 
-INDEX_ALPHABET = tuple(_current_index_alphabet)
+INDEX_ALPHABET = tuple(get_current_index_alphabet())
 INDEX_CODE = {c: i for i, c in enumerate(INDEX_ALPHABET)}
 
 from selfies.mol_graph import Atom

--- a/selfies/grammar_rules.py
+++ b/selfies/grammar_rules.py
@@ -10,9 +10,6 @@ from selfies.constants import (
 
 from selfies.index_alphabet import get_current_index_alphabet
 
-INDEX_ALPHABET = tuple(get_current_index_alphabet())
-INDEX_CODE = {c: i for i, c in enumerate(INDEX_ALPHABET)}
-
 from selfies.mol_graph import Atom
 from selfies.utils.smiles_utils import smiles_to_bond
 
@@ -82,6 +79,8 @@ def next_ring_state(
 
 
 def get_index_from_selfies(*symbols: List[str]) -> int:
+    INDEX_ALPHABET = tuple(get_current_index_alphabet())
+    INDEX_CODE = {c: i for i, c in enumerate(INDEX_ALPHABET)}
     index = 0
     for i, c in enumerate(reversed(symbols)):
         index += INDEX_CODE.get(c, 0) * (len(INDEX_CODE) ** i)
@@ -89,6 +88,9 @@ def get_index_from_selfies(*symbols: List[str]) -> int:
 
 
 def get_selfies_from_index(index: int) -> List[str]:
+    
+    INDEX_ALPHABET = tuple(get_current_index_alphabet())
+    
     if index < 0:
         raise IndexError()
     elif index == 0:

--- a/selfies/index_alphabet.py
+++ b/selfies/index_alphabet.py
@@ -26,10 +26,10 @@ _PRESET_INDEX_ALPHABETS = {
 }
 
 _index_alphabet = _PRESET_INDEX_ALPHABETS["default"]
-_index_alphabet_symbols = {
+_index_alphabet_reversed = {
     _index_alphabet.get(c): c for i, c in enumerate(_index_alphabet)
 }
-_index_alphabet_reversed = tuple(
+_index_alphabet_symbols = tuple(
     [symbol for index_value, symbol in sorted(_index_alphabet.items())]
 )
 

--- a/selfies/index_alphabet.py
+++ b/selfies/index_alphabet.py
@@ -1,17 +1,15 @@
-import functools
 import re
-from itertools import product
-from typing import List, Dict, Set, Union
+from typing import List, Dict, Union
 
 
 _DEFAULT_INDEX_ALPHABET = {
-    0: "[C]", 
-    1: "[Ring1]", 
-    2: "[Ring2]", 
-    3: "[Branch1]", 
-    4: "[=Branch1]", 
-    5: "[#Branch1]", 
-    6: "[Branch2]", 
+    0: "[C]",
+    1: "[Ring1]",
+    2: "[Ring2]",
+    3: "[Branch1]",
+    4: "[=Branch1]",
+    5: "[#Branch1]",
+    6: "[Branch2]",
     7: "[=Branch2]",
     8: "[#Branch2]",
     9: "[O]",
@@ -28,8 +26,13 @@ _PRESET_INDEX_ALPHABETS = {
 }
 
 _current_index_alphabet = _PRESET_INDEX_ALPHABETS["default"]
-_current_index_alphabet_reversed = {_current_index_alphabet.get(c): c for i, c in enumerate(_current_index_alphabet)}
-_current_index_alphabet_symbols = tuple([symbol for index_value, symbol in sorted(_current_index_alphabet.items())])
+_current_index_alphabet_reversed = {
+    _current_index_alphabet.get(c): c for i, c in enumerate(_current_index_alphabet)
+}
+_current_index_alphabet_symbols = tuple(
+    [symbol for index_value, symbol in sorted(_current_index_alphabet.items())]
+)
+
 
 def get_preset_index_alphabet(name: str) -> Dict[int, str]:
     """Returns the preset index alphabet with the given name.
@@ -61,7 +64,7 @@ def update_index_alphabet(
     If the input is a string, the new index alphabet is taken to be
     the preset named ``index_alphabet``
     (see :func:`selfies.get_preset_index_alphabet`).
-    Otherwise, the input is a dictionary representing updates to the index alphabet.
+    Otherwise, the input is a dictionary with updates for the index alphabet.
     This dictionary maps index values (the keys) to tokens (the values).
     :param index_alphabet: the name of a preset, or a dictionary
         representing the new index alphabet.
@@ -71,16 +74,16 @@ def update_index_alphabet(
     global _current_index_alphabet
     global _current_index_alphabet_symbols
     global _current_index_alphabet_reversed
-    
+
     SELFIES_ATOM_PATTERN = re.compile(
-    r"^[\[]"  # opening square bracket [
-    r"([=#/\\]?)"  # bond char
-    r"(\d*)"  # isotope number (optional, e.g. 123, 26)
-    r"([A-Z][a-z]?)"  # element symbol
-    r"([@]{0,2})"  # chiral_tag (optional, only @ and @@ supported)
-    r"((?:[H]\d)?)"  # H count (optional, e.g. H1, H3)
-    r"((?:[+-][1-9]+)?)"  # charge (optional, e.g. +1)
-    r"[]]$"  # closing square bracket ]
+        r"^[\[]"  # opening square bracket [
+        r"([=#/\\]?)"  # bond char
+        r"(\d*)"  # isotope number (optional, e.g. 123, 26)
+        r"([A-Z][a-z]?)"  # element symbol
+        r"([@]{0,2})"  # chiral_tag (optional, only @ and @@ supported)
+        r"((?:[H]\d)?)"  # H count (optional, e.g. H1, H3)
+        r"((?:[+-][1-9]+)?)"  # charge (optional, e.g. +1)
+        r"[]]$"  # closing square bracket ]
     )
 
     SELFIES_SPECIAL_TOKENS = set()
@@ -93,21 +96,25 @@ def update_index_alphabet(
 
     if isinstance(index_alphabet, str):
         _current_index_alphabet = get_preset_index_alphabet(index_alphabet)
-        _current_index_alphabet_reversed = {_current_index_alphabet.get(c): c for i, c in enumerate(_current_index_alphabet)}
-        _current_index_alphabet_symbols = tuple([symbol for index_value, symbol in sorted(_current_index_alphabet.items())])
+        _current_index_alphabet_reversed = {
+            _current_index_alphabet.get(c): c for i, c in enumerate(_current_index_alphabet)
+        }
+        _current_index_alphabet_symbols = tuple(
+            [symbol for index_value, symbol in sorted(_current_index_alphabet.items())]
+        )
 
     elif isinstance(index_alphabet, dict):
-        
+
         _updated_index_alphabet = _current_index_alphabet.copy()
         _updated_index_alphabet.update(index_alphabet)
 
         for key, value in _updated_index_alphabet.items():
-            
+
             # error checking for index values
             if key not in [i for i in range(16)]:
                 err_msg = "Invalid index value '{}' in index_alphabet".format(key)
                 raise ValueError(err_msg)
-            
+
             # error checking for index symbols
             valid = False
             m = SELFIES_ATOM_PATTERN.match(value)
@@ -118,21 +125,27 @@ def update_index_alphabet(
             if not valid:
                 err_msg = "Invalid index symbol '{}' in index_alphabet".format(value)
                 raise ValueError(err_msg)
-                
+
         # error checking for duplicate index symbols
         if not len(set(_updated_index_alphabet.values())) == 16:
             l = list(_updated_index_alphabet.values())
-            err_msg = "Duplicate index symbol(s) '{}' in index_alphabet".format(list(set([x for x in l if l.count(x) > 1])))
-            raise ValueError(err_msg) 
-                
+            err_msg = "Duplicate index symbol(s) '{}' in index_alphabet".format(
+                list(set([x for x in l if l.count(x) > 1]))
+            )
+            raise ValueError(err_msg)
+
         _current_index_alphabet = _updated_index_alphabet
-        _current_index_alphabet_reversed = {_current_index_alphabet.get(c): c for i, c in enumerate(_current_index_alphabet)}
-        _current_index_alphabet_symbols = tuple([symbol for index_value, symbol in sorted(_current_index_alphabet.items())])
+        _current_index_alphabet_reversed = {
+            _current_index_alphabet.get(c): c for i, c in enumerate(_current_index_alphabet)
+        }
+        _current_index_alphabet_symbols = tuple(
+            [symbol for index_value, symbol in sorted(_current_index_alphabet.items())]
+        )
 
     else:
         raise ValueError("index_alphabet must be a str or dict")
-        
-        
+
+
 def get_index_from_selfies(*symbols: List[str]) -> int:
     index = 0
     for i, c in enumerate(reversed(symbols)):

--- a/selfies/index_alphabet.py
+++ b/selfies/index_alphabet.py
@@ -109,7 +109,7 @@ def update_index_alphabet(
             
             # error checking for index values
             if key not in [i for i in range(16)]:
-                err_msg = "invalid index value '{}' in index_alphabet".format(key)
+                err_msg = "Invalid index value '{}' in index_alphabet".format(key)
                 raise ValueError(err_msg)
             
             # error checking for index symbols
@@ -120,7 +120,7 @@ def update_index_alphabet(
             if value in SELFIES_SPECIAL_TOKENS:
                 valid = True
             if not valid:
-                err_msg = "Duplicate index symbol '{}' in index_alphabet".format(value)
+                err_msg = "Invalid index symbol '{}' in index_alphabet".format(value)
                 raise ValueError(err_msg)
                 
         _current_index_alphabet = _updated_index_alphabet

--- a/selfies/index_alphabet.py
+++ b/selfies/index_alphabet.py
@@ -25,12 +25,12 @@ _PRESET_INDEX_ALPHABETS = {
     "default": dict(_DEFAULT_INDEX_ALPHABET),
 }
 
-_current_index_alphabet = _PRESET_INDEX_ALPHABETS["default"]
-_current_index_alphabet_reversed = {
-    _current_index_alphabet.get(c): c for i, c in enumerate(_current_index_alphabet)
+_index_alphabet = _PRESET_INDEX_ALPHABETS["default"]
+_index_alphabet_symbols = {
+    _index_alphabet.get(c): c for i, c in enumerate(_index_alphabet)
 }
-_current_index_alphabet_symbols = tuple(
-    [symbol for index_value, symbol in sorted(_current_index_alphabet.items())]
+_index_alphabet_reversed = tuple(
+    [symbol for index_value, symbol in sorted(_index_alphabet.items())]
 )
 
 
@@ -53,27 +53,27 @@ def get_index_alphabet() -> Dict[int, str]:
         which maps index values (the keys) to tokens (the values).
     """
 
-    global _current_index_alphabet
-    return dict(_current_index_alphabet)
+    global _index_alphabet
+    return dict(_index_alphabet)
 
 
 def update_index_alphabet(
-        index_alphabet: Union[str, Dict[int, str]] = "default"
+        index_alphabet_updates: Union[str, Dict[int, str]] = "default"
 ) -> None:
     """Updates the index alphabet that :mod:`selfies` operates on.
     If the input is a string, the new index alphabet is taken to be
-    the preset named ``index_alphabet``
+    the preset named ``index_alphabet_updates``
     (see :func:`selfies.get_preset_index_alphabet`).
     Otherwise, the input is a dictionary with updates for the index alphabet.
     This dictionary maps index values (the keys) to tokens (the values).
-    :param index_alphabet: the name of a preset, or a dictionary
+    :param index_alphabet_updates: the name of a preset, or a dictionary
         representing the new index alphabet.
     :return: ``None``.
     """
 
-    global _current_index_alphabet
-    global _current_index_alphabet_symbols
-    global _current_index_alphabet_reversed
+    global _index_alphabet
+    global _index_alphabet_symbols
+    global _index_alphabet_reversed
 
     SELFIES_ATOM_PATTERN = re.compile(
         r"^[\[]"  # opening square bracket [
@@ -94,25 +94,25 @@ def update_index_alphabet(
         SELFIES_SPECIAL_TOKENS.add("[=Branch{}]".format(i))
         SELFIES_SPECIAL_TOKENS.add("[#Branch{}]".format(i))
 
-    if isinstance(index_alphabet, str):
-        _current_index_alphabet = get_preset_index_alphabet(index_alphabet)
-        _current_index_alphabet_reversed = {
-            _current_index_alphabet.get(c): c for i, c in enumerate(_current_index_alphabet)
+    if isinstance(index_alphabet_updates, str):
+        _index_alphabet = get_preset_index_alphabet(index_alphabet_updates)
+        _index_alphabet_reversed = {
+            _index_alphabet.get(c): c for i, c in enumerate(_index_alphabet)
         }
-        _current_index_alphabet_symbols = tuple(
-            [symbol for index_value, symbol in sorted(_current_index_alphabet.items())]
+        _index_alphabet = tuple(
+            [symbol for index_value, symbol in sorted(_index_alphabet.items())]
         )
 
-    elif isinstance(index_alphabet, dict):
+    elif isinstance(index_alphabet_updates, dict):
 
-        _updated_index_alphabet = _current_index_alphabet.copy()
-        _updated_index_alphabet.update(index_alphabet)
+        _updated_index_alphabet = _index_alphabet.copy()
+        _updated_index_alphabet.update(index_alphabet_updates)
 
         for key, value in _updated_index_alphabet.items():
 
             # error checking for index values
             if key not in [i for i in range(16)]:
-                err_msg = "Invalid index value '{}' in index_alphabet".format(key)
+                err_msg = "Invalid index value '{}' in index_alphabet_updates".format(key)
                 raise ValueError(err_msg)
 
             # error checking for index symbols
@@ -123,23 +123,23 @@ def update_index_alphabet(
             if value in SELFIES_SPECIAL_TOKENS:
                 valid = True
             if not valid:
-                err_msg = "Invalid index symbol '{}' in index_alphabet".format(value)
+                err_msg = "Invalid index symbol '{}' in index_alphabet_updates".format(value)
                 raise ValueError(err_msg)
 
         # error checking for duplicate index symbols
         if not len(set(_updated_index_alphabet.values())) == 16:
             l = list(_updated_index_alphabet.values())
-            err_msg = "Duplicate index symbol(s) '{}' in index_alphabet".format(
+            err_msg = "Duplicate index symbol(s) '{}' in index_alphabet_updates".format(
                 list(set([x for x in l if l.count(x) > 1]))
             )
             raise ValueError(err_msg)
 
-        _current_index_alphabet = _updated_index_alphabet
-        _current_index_alphabet_reversed = {
-            _current_index_alphabet.get(c): c for i, c in enumerate(_current_index_alphabet)
+        _index_alphabet = _updated_index_alphabet
+        _index_alphabet_reversed = {
+            _index_alphabet.get(c): c for i, c in enumerate(_index_alphabet)
         }
-        _current_index_alphabet_symbols = tuple(
-            [symbol for index_value, symbol in sorted(_current_index_alphabet.items())]
+        _index_alphabet_symbols = tuple(
+            [symbol for index_value, symbol in sorted(_index_alphabet.items())]
         )
 
     else:
@@ -149,7 +149,7 @@ def update_index_alphabet(
 def get_index_from_selfies(*symbols: List[str]) -> int:
     index = 0
     for i, c in enumerate(reversed(symbols)):
-        index += _current_index_alphabet_reversed.get(c, 0) * (len(_current_index_alphabet_reversed) ** i)
+        index += _index_alphabet_reversed.get(c, 0) * (16 ** i)
     return index
 
 
@@ -157,11 +157,11 @@ def get_selfies_from_index(index: int) -> List[str]:
     if index < 0:
         raise IndexError()
     elif index == 0:
-        return [_current_index_alphabet_symbols[0]]
+        return [_index_alphabet_symbols[0]]
 
     symbols = []
-    base = len(_current_index_alphabet_symbols)
+    base = len(_index_alphabet_symbols)
     while index:
-        symbols.append(_current_index_alphabet_symbols[index % base])
+        symbols.append(_index_alphabet_symbols[index % base])
         index //= base
     return symbols[::-1]

--- a/selfies/index_alphabet.py
+++ b/selfies/index_alphabet.py
@@ -29,7 +29,7 @@ _PRESET_INDEX_ALPHABETS = {
 
 _current_index_alphabet = _PRESET_INDEX_ALPHABETS["default"]
 _current_index_symbols = tuple([symbol for index_value, symbol in sorted(_current_index_alphabet.items())])
-_current_index_code = {c: i for i, c in enumerate(_current_index_symbols)}
+_current_index_alphabet_reversed = {c: i for i, c in enumerate(_current_index_symbols)}
 
 def get_preset_index_alphabet(name: str) -> Dict[int, str]:
     """Returns the preset index alphabet with the given name.
@@ -69,6 +69,8 @@ def update_index_alphabet(
     """
 
     global _current_index_alphabet
+    global _current_index_symbols
+    global _current_index_alphabet_reversed
     
     SELFIES_ATOM_PATTERN = re.compile(
     r"^[\[]"  # opening square bracket [
@@ -123,7 +125,7 @@ def update_index_alphabet(
                 
         _current_index_alphabet = _updated_index_alphabet
         _current_index_symbols = tuple([symbol for index_value, symbol in sorted(_current_index_alphabet.items())])
-        _current_index_code = {c: i for i, c in enumerate(_current_index_symbols)}
+        _current_index_alphabet_reversed = {c: i for i, c in enumerate(_current_index_symbols)}
 
     else:
         raise ValueError("index_alphabet must be a str or dict")
@@ -132,7 +134,7 @@ def update_index_alphabet(
 def get_index_from_selfies(*symbols: List[str]) -> int:
     index = 0
     for i, c in enumerate(reversed(symbols)):
-        index += _current_index_code.get(c, 0) * (len(_current_index_code) ** i)
+        index += _current_index_alphabet_reversed.get(c, 0) * (len(_current_index_alphabet_reversed) ** i)
     return index
 
 

--- a/selfies/index_alphabet.py
+++ b/selfies/index_alphabet.py
@@ -148,8 +148,9 @@ def update_index_alphabet(
 
 def get_index_from_selfies(*symbols: List[str]) -> int:
     index = 0
+    base = len(_index_alphabet_reversed)
     for i, c in enumerate(reversed(symbols)):
-        index += _index_alphabet_reversed.get(c, 0) * (16 ** i)
+        index += _index_alphabet_reversed.get(c, 0) * (base ** i)
     return index
 
 

--- a/selfies/index_alphabet.py
+++ b/selfies/index_alphabet.py
@@ -97,7 +97,7 @@ def set_index_alphabet(
             err_msg = "invalid length '{}' for index_alphabet".format(len(index_alphabet))
             raise ValueError(err_msg)
         
-        # error check for values
+        # error checking for values
         if not list(set(index_alphabet.values())) == [i for i in range(16)]:
             err_msg = "invalid index values in index_alphabet"
             raise ValueError(err_msg)

--- a/selfies/index_alphabet.py
+++ b/selfies/index_alphabet.py
@@ -43,6 +43,7 @@ def get_preset_index_alphabet(name: str) -> Dict[str, int]:
         raise ValueError("unrecognized preset name '{}'".format(name))
     return dict(_PRESET_INDEX_ALPHABETS[name])
 
+
 def get_current_index_alphabet() -> Dict[str, int]:
     """Returns the semantic constraints that :mod:`selfies` is currently
     operating on.
@@ -52,6 +53,7 @@ def get_current_index_alphabet() -> Dict[str, int]:
 
     global _current_index_alphabet
     return dict(_current_index_alphabet)
+
 
 def set_index_alphabet(
         index_alphabet: Union[str, Dict[str, int]] = "default"

--- a/selfies/index_alphabet.py
+++ b/selfies/index_alphabet.py
@@ -67,8 +67,6 @@ def set_index_alphabet(
     """
 
     global _current_index_alphabet
-    global INDEX_ALPHABET
-    global INDEX_CODE
     
     SELFIES_ATOM_PATTERN = re.compile(
     r"^[\[]"  # opening square bracket [

--- a/selfies/index_alphabet.py
+++ b/selfies/index_alphabet.py
@@ -41,6 +41,17 @@ def get_preset_index_alphabet(name: str) -> Dict[str, int]:
     return dict(_PRESET_INDEX_ALPHABETS[name])
 
 
+def get_current_index_alphabet() -> Dict[str, int]:
+    """Returns the semantic constraints that :mod:`selfies` is currently
+    operating on.
+    :return: the current semantic constraints, represented as a dictionary
+        which maps tokens (the keys) to their index values (the values).
+    """
+
+    global _current_index_alphabet
+    return dict(_current_index_alphabet)
+
+
 def set_index_alphabet(
         index_alphabet: Union[str, Dict[str, int]] = "default"
 ) -> None:
@@ -111,15 +122,3 @@ def set_index_alphabet(
         
     # clear cache since we changed index alphabet
     get_current_index_alphabet.cache_clear()
-
-    
-@functools.lru_cache()
-def get_current_index_alphabet() -> Dict[str, int]:
-    """Returns the semantic constraints that :mod:`selfies` is currently
-    operating on.
-    :return: the current semantic constraints, represented as a dictionary
-        which maps tokens (the keys) to their index values (the values).
-    """
-
-    global _current_index_alphabet
-    return dict(_current_index_alphabet)

--- a/selfies/index_alphabet.py
+++ b/selfies/index_alphabet.py
@@ -29,9 +29,6 @@ _PRESET_INDEX_ALPHABETS = {
 
 _current_index_alphabet = _PRESET_INDEX_ALPHABETS["default"]
 
-INDEX_ALPHABET = tuple(_current_index_alphabet)
-INDEX_CODE = {c: i for i, c in enumerate(INDEX_ALPHABET)}
-
 def get_preset_index_alphabet(name: str) -> Dict[str, int]:
     """Returns the preset index alphabet with the given name.
     :param name: the preset name: ``default`` or XXX or XXX.
@@ -121,8 +118,6 @@ def set_index_alphabet(
                 raise ValueError(err_msg)
                 
         _current_index_alphabet = dict(index_alphabet)
-        INDEX_ALPHABET = tuple(_current_index_alphabet)
-        INDEX_CODE = {c: i for i, c in enumerate(INDEX_ALPHABET)}
 
     else:
         raise ValueError("index_alphabet must be a str or dict")

--- a/selfies/index_alphabet.py
+++ b/selfies/index_alphabet.py
@@ -41,7 +41,7 @@ def get_preset_index_alphabet(name: str) -> Dict[str, int]:
     return dict(_PRESET_INDEX_ALPHABETS[name])
 
 
-def get_current_index_alphabet() -> Dict[str, int]:
+def get_index_alphabet() -> Dict[str, int]:
     """Returns the semantic constraints that :mod:`selfies` is currently
     operating on.
     :return: the current semantic constraints, represented as a dictionary

--- a/selfies/index_alphabet.py
+++ b/selfies/index_alphabet.py
@@ -119,5 +119,3 @@ def set_index_alphabet(
 
     else:
         raise ValueError("index_alphabet must be a str or dict")
-        
-    get_current_index_alphabet.cache_clear()

--- a/selfies/index_alphabet.py
+++ b/selfies/index_alphabet.py
@@ -40,7 +40,7 @@ def get_preset_index_alphabet(name: str) -> Dict[str, int]:
         raise ValueError("unrecognized preset name '{}'".format(name))
     return dict(_PRESET_INDEX_ALPHABETS[name])
 
-
+@functools.lru_cache()
 def get_current_index_alphabet() -> Dict[str, int]:
     """Returns the semantic constraints that :mod:`selfies` is currently
     operating on.
@@ -119,3 +119,4 @@ def set_index_alphabet(
 
     else:
         raise ValueError("index_alphabet must be a str or dict")
+    get_current_index_alphabet.cache_clear()

--- a/selfies/index_alphabet.py
+++ b/selfies/index_alphabet.py
@@ -99,7 +99,7 @@ def update_index_alphabet(
         _index_alphabet_reversed = {
             _index_alphabet.get(c): c for i, c in enumerate(_index_alphabet)
         }
-        _index_alphabet = tuple(
+        _index_alphabet_symbols = tuple(
             [symbol for index_value, symbol in sorted(_index_alphabet.items())]
         )
 

--- a/selfies/index_alphabet.py
+++ b/selfies/index_alphabet.py
@@ -53,28 +53,6 @@ def get_current_index_alphabet() -> Dict[str, int]:
     global _current_index_alphabet
     return dict(_current_index_alphabet)
 
-
-
-SELFIES_ATOM_PATTERN = re.compile(
-    r"^[\[]"  # opening square bracket [
-    r"([=#/\\]?)"  # bond char
-    r"(\d*)"  # isotope number (optional, e.g. 123, 26)
-    r"([A-Z][a-z]?)"  # element symbol
-    r"([@]{0,2})"  # chiral_tag (optional, only @ and @@ supported)
-    r"((?:[H]\d)?)"  # H count (optional, e.g. H1, H3)
-    r"((?:[+-][1-9]+)?)"  # charge (optional, e.g. +1)
-    r"[]]$"  # closing square bracket ]
-)
-
-SELFIES_SPECIAL_TOKENS = set()
-for i in range(1, 4):
-    SELFIES_SPECIAL_TOKENS.add("[Ring{}]".format(i))
-    SELFIES_SPECIAL_TOKENS.add("[=Ring{}]".format(i))
-    SELFIES_SPECIAL_TOKENS.add("[Branch{}]".format(i))
-    SELFIES_SPECIAL_TOKENS.add("[=Branch{}]".format(i))
-    SELFIES_SPECIAL_TOKENS.add("[#Branch{}]".format(i))
-
-
 def set_index_alphabet(
         index_alphabet: Union[str, Dict[str, int]] = "default"
 ) -> None:
@@ -92,6 +70,25 @@ def set_index_alphabet(
     global _current_index_alphabet
     global INDEX_ALPHABET
     global INDEX_CODE
+    
+    SELFIES_ATOM_PATTERN = re.compile(
+    r"^[\[]"  # opening square bracket [
+    r"([=#/\\]?)"  # bond char
+    r"(\d*)"  # isotope number (optional, e.g. 123, 26)
+    r"([A-Z][a-z]?)"  # element symbol
+    r"([@]{0,2})"  # chiral_tag (optional, only @ and @@ supported)
+    r"((?:[H]\d)?)"  # H count (optional, e.g. H1, H3)
+    r"((?:[+-][1-9]+)?)"  # charge (optional, e.g. +1)
+    r"[]]$"  # closing square bracket ]
+    )
+
+    SELFIES_SPECIAL_TOKENS = set()
+    for i in range(1, 4):
+        SELFIES_SPECIAL_TOKENS.add("[Ring{}]".format(i))
+        SELFIES_SPECIAL_TOKENS.add("[=Ring{}]".format(i))
+        SELFIES_SPECIAL_TOKENS.add("[Branch{}]".format(i))
+        SELFIES_SPECIAL_TOKENS.add("[=Branch{}]".format(i))
+        SELFIES_SPECIAL_TOKENS.add("[#Branch{}]".format(i))
 
     if isinstance(index_alphabet, str):
         _current_constraints = get_preset_index_alphabets(index_alphabet)
@@ -121,7 +118,6 @@ def set_index_alphabet(
                 err_msg = "invalid key '{}' in index_alphabet".format(key)
                 raise ValueError(err_msg)
                 
-
         _current_index_alphabet = dict(index_alphabet)
         INDEX_ALPHABET = tuple(_current_index_alphabet)
         INDEX_CODE = {c: i for i, c in enumerate(INDEX_ALPHABET)}

--- a/selfies/index_alphabet.py
+++ b/selfies/index_alphabet.py
@@ -1,7 +1,7 @@
 import functools
 import re
 from itertools import product
-from typing import Dict, Set, Union
+from typing import List, Dict, Set, Union
 
 
 _DEFAULT_INDEX_ALPHABET = {

--- a/selfies/index_alphabet.py
+++ b/selfies/index_alphabet.py
@@ -28,8 +28,8 @@ _PRESET_INDEX_ALPHABETS = {
 }
 
 _current_index_alphabet = _PRESET_INDEX_ALPHABETS["default"]
+_current_index_alphabet_reversed = {_current_index_alphabet.get(c): c for i, c in enumerate(_current_index_alphabet)}
 _current_index_alphabet_symbols = tuple([symbol for index_value, symbol in sorted(_current_index_alphabet.items())])
-_current_index_alphabet_reversed = {c: i for i, c in enumerate(_current_index_symbols)}
 
 def get_preset_index_alphabet(name: str) -> Dict[int, str]:
     """Returns the preset index alphabet with the given name.
@@ -126,8 +126,8 @@ def update_index_alphabet(
                 raise ValueError(err_msg)
                 
         _current_index_alphabet = _updated_index_alphabet
+        _current_index_alphabet_reversed = {_current_index_alphabet.get(c): c for i, c in enumerate(_current_index_alphabet)}
         _current_index_alphabet_symbols = tuple([symbol for index_value, symbol in sorted(_current_index_alphabet.items())])
-        _current_index_alphabet_reversed = {c: i for i, c in enumerate(_current_index_symbols)}
 
     else:
         raise ValueError("index_alphabet must be a str or dict")

--- a/selfies/index_alphabet.py
+++ b/selfies/index_alphabet.py
@@ -28,6 +28,8 @@ _PRESET_INDEX_ALPHABETS = {
 }
 
 _current_index_alphabet = _PRESET_INDEX_ALPHABETS["default"]
+_current_index_symbols = tuple([symbol for index_value, symbol in sorted(_current_index_alphabet.items())])
+_current_index_code = {c: i for i, c in enumerate(_current_index_symbols)}
 
 def get_preset_index_alphabet(name: str) -> Dict[int, str]:
     """Returns the preset index alphabet with the given name.
@@ -120,32 +122,29 @@ def update_index_alphabet(
                 raise ValueError(err_msg)
                 
         _current_index_alphabet = _updated_index_alphabet
+        _current_index_symbols = tuple([symbol for index_value, symbol in sorted(_current_index_alphabet.items())])
+        _current_index_code = {c: i for i, c in enumerate(_current_index_symbols)}
 
     else:
         raise ValueError("index_alphabet must be a str or dict")
         
         
 def get_index_from_selfies(*symbols: List[str]) -> int:
-    index_alphabet = tuple(_current_index_alphabet.values())
-    index_code = {c: i for i, c in enumerate(index_alphabet)}
     index = 0
     for i, c in enumerate(reversed(symbols)):
-        index += index_code.get(c, 0) * (len(index_code) ** i)
+        index += _current_index_code.get(c, 0) * (len(_current_index_code) ** i)
     return index
 
 
 def get_selfies_from_index(index: int) -> List[str]:
-    
-    index_alphabet = tuple(_current_index_alphabet.values())
-    
     if index < 0:
         raise IndexError()
     elif index == 0:
-        return [index_alphabet[0]]
+        return [_current_index_symbols[0]]
 
     symbols = []
-    base = len(index_alphabet)
+    base = len(_current_index_symbols)
     while index:
-        symbols.append(index_alphabet[index % base])
+        symbols.append(_current_index_symbols[index % base])
         index //= base
     return symbols[::-1]

--- a/selfies/index_alphabet.py
+++ b/selfies/index_alphabet.py
@@ -128,9 +128,9 @@ def update_index_alphabet(
 
         # error checking for duplicate index symbols
         if not len(set(_updated_index_alphabet.values())) == 16:
-            l = list(_updated_index_alphabet.values())
+            symbol_list = list(_updated_index_alphabet.values())
             err_msg = "Duplicate index symbol(s) '{}' in index_alphabet_updates".format(
-                list(set([x for x in l if l.count(x) > 1]))
+                list(set([x for x in symbol_list if symbol_list.count(x) > 1]))
             )
             raise ValueError(err_msg)
 

--- a/selfies/index_alphabet.py
+++ b/selfies/index_alphabet.py
@@ -134,7 +134,7 @@ def update_index_alphabet(
 def get_index_from_selfies(*symbols: List[str]) -> int:
     index = 0
     for i, c in enumerate(reversed(symbols)):
-        index += _current_index_alphabet.get(c, 0) * (len(_current_index_alphabet) ** i)
+        index += _current_index_alphabet_reversed.get(c, 0) * (len(_current_index_alphabet_reversed) ** i)
     return index
 
 

--- a/selfies/index_alphabet.py
+++ b/selfies/index_alphabet.py
@@ -93,6 +93,8 @@ def update_index_alphabet(
 
     if isinstance(index_alphabet, str):
         _current_index_alphabet = get_preset_index_alphabet(index_alphabet)
+        _current_index_symbols = tuple([symbol for index_value, symbol in sorted(_current_index_alphabet.items())])
+        _current_index_alphabet_reversed = {c: i for i, c in enumerate(_current_index_symbols)}
 
     elif isinstance(index_alphabet, dict):
         

--- a/selfies/index_alphabet.py
+++ b/selfies/index_alphabet.py
@@ -119,3 +119,5 @@ def set_index_alphabet(
 
     else:
         raise ValueError("index_alphabet must be a str or dict")
+        
+    get_current_index_alphabet.cache_clear()

--- a/selfies/index_alphabet.py
+++ b/selfies/index_alphabet.py
@@ -58,7 +58,7 @@ def set_index_alphabet(
     """Updates the index alphabet that :mod:`selfies` operates on.
     If the input is a string, the new index alphabet is taken to be
     the preset named ``index_alphabet``
-    (see :func:`selfies.get_preset_index_alphabets`).
+    (see :func:`selfies.get_preset_index_alphabet`).
     Otherwise, the input is a dictionary representing the new index alphabet.
     This dictionary maps tokens (the keys) to index values (the values).
     :param index_alphabet: the name of a preset, or a dictionary
@@ -88,7 +88,7 @@ def set_index_alphabet(
         SELFIES_SPECIAL_TOKENS.add("[#Branch{}]".format(i))
 
     if isinstance(index_alphabet, str):
-        _current_constraints = get_preset_index_alphabets(index_alphabet)
+        _current_constraints = get_preset_index_alphabet(index_alphabet)
 
     elif isinstance(index_alphabet, dict):
         

--- a/selfies/index_alphabet.py
+++ b/selfies/index_alphabet.py
@@ -33,7 +33,7 @@ INDEX_ALPHABET = tuple(_current_index_alphabet)
 INDEX_CODE = {c: i for i, c in enumerate(INDEX_ALPHABET)}
 
 def get_preset_index_alphabets(name: str) -> Dict[str, int]:
-    """the preset index alphabet with the given name.
+    """Returns the preset index alphabet with the given name.
     :param name: the preset name: ``default``.
     :return: the preset index alphabet with the specified name, represented as
         a dictionary which maps tokens (the keys) to their index values (the values).

--- a/selfies/index_alphabet.py
+++ b/selfies/index_alphabet.py
@@ -40,17 +40,6 @@ def get_preset_index_alphabet(name: str) -> Dict[str, int]:
         raise ValueError("unrecognized preset name '{}'".format(name))
     return dict(_PRESET_INDEX_ALPHABETS[name])
 
-@functools.lru_cache()
-def get_current_index_alphabet() -> Dict[str, int]:
-    """Returns the semantic constraints that :mod:`selfies` is currently
-    operating on.
-    :return: the current semantic constraints, represented as a dictionary
-        which maps tokens (the keys) to their index values (the values).
-    """
-
-    global _current_index_alphabet
-    return dict(_current_index_alphabet)
-
 
 def set_index_alphabet(
         index_alphabet: Union[str, Dict[str, int]] = "default"
@@ -119,4 +108,18 @@ def set_index_alphabet(
 
     else:
         raise ValueError("index_alphabet must be a str or dict")
+        
+    # clear cache since we changed index alphabet
     get_current_index_alphabet.cache_clear()
+
+    
+@functools.lru_cache()
+def get_current_index_alphabet() -> Dict[str, int]:
+    """Returns the semantic constraints that :mod:`selfies` is currently
+    operating on.
+    :return: the current semantic constraints, represented as a dictionary
+        which maps tokens (the keys) to their index values (the values).
+    """
+
+    global _current_index_alphabet
+    return dict(_current_index_alphabet)

--- a/selfies/index_alphabet.py
+++ b/selfies/index_alphabet.py
@@ -28,7 +28,7 @@ _PRESET_INDEX_ALPHABETS = {
 }
 
 _current_index_alphabet = _PRESET_INDEX_ALPHABETS["default"]
-_current_index_symbols = tuple([symbol for index_value, symbol in sorted(_current_index_alphabet.items())])
+_current_index_alphabet_symbols = tuple([symbol for index_value, symbol in sorted(_current_index_alphabet.items())])
 _current_index_alphabet_reversed = {c: i for i, c in enumerate(_current_index_symbols)}
 
 def get_preset_index_alphabet(name: str) -> Dict[int, str]:
@@ -69,7 +69,7 @@ def update_index_alphabet(
     """
 
     global _current_index_alphabet
-    global _current_index_symbols
+    global _current_index_alphabet_symbols
     global _current_index_alphabet_reversed
     
     SELFIES_ATOM_PATTERN = re.compile(
@@ -93,7 +93,7 @@ def update_index_alphabet(
 
     if isinstance(index_alphabet, str):
         _current_index_alphabet = get_preset_index_alphabet(index_alphabet)
-        _current_index_symbols = tuple([symbol for index_value, symbol in sorted(_current_index_alphabet.items())])
+        _current_index_alphabet_symbols = tuple([symbol for index_value, symbol in sorted(_current_index_alphabet.items())])
         _current_index_alphabet_reversed = {c: i for i, c in enumerate(_current_index_symbols)}
 
     elif isinstance(index_alphabet, dict):
@@ -126,7 +126,7 @@ def update_index_alphabet(
                 raise ValueError(err_msg)
                 
         _current_index_alphabet = _updated_index_alphabet
-        _current_index_symbols = tuple([symbol for index_value, symbol in sorted(_current_index_alphabet.items())])
+        _current_index_alphabet_symbols = tuple([symbol for index_value, symbol in sorted(_current_index_alphabet.items())])
         _current_index_alphabet_reversed = {c: i for i, c in enumerate(_current_index_symbols)}
 
     else:
@@ -144,11 +144,11 @@ def get_selfies_from_index(index: int) -> List[str]:
     if index < 0:
         raise IndexError()
     elif index == 0:
-        return [_current_index_symbols[0]]
+        return [_current_index_alphabet_symbols[0]]
 
     symbols = []
-    base = len(_current_index_symbols)
+    base = len(_current_index_alphabet_symbols)
     while index:
-        symbols.append(_current_index_symbols[index % base])
+        symbols.append(_current_index_alphabet_symbols[index % base])
         index //= base
     return symbols[::-1]

--- a/selfies/index_alphabet.py
+++ b/selfies/index_alphabet.py
@@ -100,12 +100,6 @@ def update_index_alphabet(
         
         _updated_index_alphabet = _current_index_alphabet.copy()
         _updated_index_alphabet.update(index_alphabet)
-        
-        # error checking for duplicate index symbols
-        if not len(set(_updated_index_alphabet.values())) == 16:
-            l = list(_updated_index_alphabet.values())
-            err_msg = "Duplicate index symbol(s) '{}' in index_alphabet".format(list(set([x for x in l if l.count(x) > 1])))
-            raise ValueError(err_msg)
 
         for key, value in _updated_index_alphabet.items():
             
@@ -124,6 +118,12 @@ def update_index_alphabet(
             if not valid:
                 err_msg = "Invalid index symbol '{}' in index_alphabet".format(value)
                 raise ValueError(err_msg)
+                
+        # error checking for duplicate index symbols
+        if not len(set(_updated_index_alphabet.values())) == 16:
+            l = list(_updated_index_alphabet.values())
+            err_msg = "Duplicate index symbol(s) '{}' in index_alphabet".format(list(set([x for x in l if l.count(x) > 1])))
+            raise ValueError(err_msg) 
                 
         _current_index_alphabet = _updated_index_alphabet
         _current_index_alphabet_reversed = {_current_index_alphabet.get(c): c for i, c in enumerate(_current_index_alphabet)}

--- a/selfies/index_alphabet.py
+++ b/selfies/index_alphabet.py
@@ -134,7 +134,7 @@ def update_index_alphabet(
 def get_index_from_selfies(*symbols: List[str]) -> int:
     index = 0
     for i, c in enumerate(reversed(symbols)):
-        index += _current_index_alphabet_reversed.get(c, 0) * (len(_current_index_alphabet_reversed) ** i)
+        index += _current_index_alphabet.get(i, 0) * (len(_current_index_alphabet) ** c)
     return index
 
 

--- a/selfies/index_alphabet.py
+++ b/selfies/index_alphabet.py
@@ -47,9 +47,9 @@ def get_preset_index_alphabet(name: str) -> Dict[int, str]:
 
 
 def get_index_alphabet() -> Dict[int, str]:
-    """Returns the semantic constraints that :mod:`selfies` is currently
+    """Returns the index alphabet that :mod:`selfies` is currently
     operating on.
-    :return: the current semantic constraints, represented as a dictionary
+    :return: the current index alphabet, represented as a dictionary
         which maps index values (the keys) to tokens (the values).
     """
 

--- a/selfies/index_alphabet.py
+++ b/selfies/index_alphabet.py
@@ -134,7 +134,7 @@ def update_index_alphabet(
 def get_index_from_selfies(*symbols: List[str]) -> int:
     index = 0
     for i, c in enumerate(reversed(symbols)):
-        index += _current_index_alphabet.get(i, 0) * (len(_current_index_alphabet) ** c)
+        index += _current_index_alphabet.get(c, 0) * (len(_current_index_alphabet) ** i)
     return index
 
 

--- a/selfies/index_alphabet.py
+++ b/selfies/index_alphabet.py
@@ -126,7 +126,7 @@ def update_index_alphabet(
         
         
 def get_index_from_selfies(*symbols: List[str]) -> int:
-    index_alphabet = tuple(sorted(_current_index_alphabet.values()))
+    index_alphabet = tuple(_current_index_alphabet.values())
     index_code = {c: i for i, c in enumerate(index_alphabet)}
     index = 0
     for i, c in enumerate(reversed(symbols)):
@@ -136,7 +136,7 @@ def get_index_from_selfies(*symbols: List[str]) -> int:
 
 def get_selfies_from_index(index: int) -> List[str]:
     
-    index_alphabet = tuple(sorted(_current_index_alphabet.values()))
+    index_alphabet = tuple(_current_index_alphabet.values())
     
     if index < 0:
         raise IndexError()

--- a/selfies/index_alphabet.py
+++ b/selfies/index_alphabet.py
@@ -32,9 +32,9 @@ _current_index_alphabet = _PRESET_INDEX_ALPHABETS["default"]
 INDEX_ALPHABET = tuple(_current_index_alphabet)
 INDEX_CODE = {c: i for i, c in enumerate(INDEX_ALPHABET)}
 
-def get_preset_index_alphabets(name: str) -> Dict[str, int]:
+def get_preset_index_alphabet(name: str) -> Dict[str, int]:
     """Returns the preset index alphabet with the given name.
-    :param name: the preset name: ``default``.
+    :param name: the preset name: ``default`` or XXX or XXX.
     :return: the preset index alphabet with the specified name, represented as
         a dictionary which maps tokens (the keys) to their index values (the values).
     """

--- a/selfies/index_alphabet.py
+++ b/selfies/index_alphabet.py
@@ -88,7 +88,7 @@ def set_index_alphabet(
         SELFIES_SPECIAL_TOKENS.add("[#Branch{}]".format(i))
 
     if isinstance(index_alphabet, str):
-        _current_constraints = get_preset_index_alphabet(index_alphabet)
+        _current_index_alphabet = get_preset_index_alphabet(index_alphabet)
 
     elif isinstance(index_alphabet, dict):
         

--- a/selfies/index_alphabet.py
+++ b/selfies/index_alphabet.py
@@ -126,7 +126,7 @@ def update_index_alphabet(
         
         
 def get_index_from_selfies(*symbols: List[str]) -> int:
-    index_alphabet = tuple(sorted(_current_index_alphabet))
+    index_alphabet = tuple(sorted(_current_index_alphabet.values()))
     index_code = {c: i for i, c in enumerate(index_alphabet)}
     index = 0
     for i, c in enumerate(reversed(symbols)):
@@ -136,7 +136,7 @@ def get_index_from_selfies(*symbols: List[str]) -> int:
 
 def get_selfies_from_index(index: int) -> List[str]:
     
-    index_alphabet = tuple(sorted(_current_index_alphabet))
+    index_alphabet = tuple(sorted(_current_index_alphabet.values()))
     
     if index < 0:
         raise IndexError()

--- a/selfies/index_alphabet.py
+++ b/selfies/index_alphabet.py
@@ -119,6 +119,3 @@ def set_index_alphabet(
 
     else:
         raise ValueError("index_alphabet must be a str or dict")
-        
-    # clear cache since we changed index alphabet
-    get_current_index_alphabet.cache_clear()

--- a/selfies/index_alphabet.py
+++ b/selfies/index_alphabet.py
@@ -93,8 +93,8 @@ def update_index_alphabet(
 
     if isinstance(index_alphabet, str):
         _current_index_alphabet = get_preset_index_alphabet(index_alphabet)
+        _current_index_alphabet_reversed = {_current_index_alphabet.get(c): c for i, c in enumerate(_current_index_alphabet)}
         _current_index_alphabet_symbols = tuple([symbol for index_value, symbol in sorted(_current_index_alphabet.items())])
-        _current_index_alphabet_reversed = {c: i for i, c in enumerate(_current_index_symbols)}
 
     elif isinstance(index_alphabet, dict):
         


### PR DESCRIPTION
Added index symbol customization functionality following the style of the bond constraints code to address #69 

index_alphabet.py includes three new functions:
- get_preset_index_alphabet 

```
sf.get_preset_index_alphabet('default')
```

- get_current_index_alphabet

```
sf.get_current_index_alphabet()
```

- set_index_alphabet

```
new_index_alphabet = {
    "[1C]": 0, 
    "[2C]": 1, 
    "[3C]": 2, 
    "[4C]": 3, 
    "[5C]": 4, 
    "[6C]": 5, 
    "[7C]": 6, 
    "[8C]": 7,
    "[9C]": 8,
    "[10C]": 9,
    "[11C]": 10,
    "[12C]": 11,
    "[13C]": 12,
    "[14C]": 13,
    "[15C]": 14,
    "[16C]": 15
}

sf.set_index_alphabet(new_index_alphabet)
```

Currently I've only included one preset index alphabet, the default one. Having multiple presets may or may not be useful, remains to be seen how much different index alphabets affect performance on different tasks I suppose.

New index alphabets can be set by passing a dictionary with tokens as keys and indices as values. Checks to make sure the passed dictionary has 16 keys, each key is a valid atom or ring/branch token, and that the set of dictionary values includes all integers 0-15