### PR TITLE
Improvements to attribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v2.1.0 - [to be announced shortly]
 
 ### Added:
-- optional attribution to map encoder/decoder output string back to input string (Issue #48)
+- optional attribution to map encoder/decoder output string back to input string (Issue #48, #79)
 
 ## v2.0.0 - 21.10.2021
 

--- a/README.md
+++ b/README.md
@@ -165,27 +165,20 @@ for smiles_token, a in attr:
     if a:
         for j, selfies_token in a:
             print(f'\t{j}:{selfies_token}')
+
 # output
 SELFIES [C][N][C][Branch1][C][P][C][C][Ring1][=Branch1]
 SMILES C1NC(P)CC1
 Attribution:
-C
-	0:[C]
-N
-	1:[N]
-C
-	2:[C]
-P
-	3:[Branch1]
-	5:[P]
-C
-	6:[C]
-C
-	7:[C]
+AttributionMap(index=0, token='C', attribution=[Attribution(index=0, token='[C]')])
+AttributionMap(index=4, token='N', attribution=[Attribution(index=1, token='[N]')])
+AttributionMap(index=6, token='C', attribution=[Attribution(index=2, token='[C]')])
+AttributionMap(index=9, token='P', attribution=[Attribution(index=3, token='[Branch1]'), Attribution(index=5, token='[P]')])
+AttributionMap(index=12, token='C', attribution=[Attribution(index=6, token='[C]')])
+AttributionMap(index=14, token='C', attribution=[Attribution(index=7, token='[C]')])
 ```
 
-``attr`` is a list of tuples containing the output token and the SELFIES tokens and indices that led to it. For example, the ``P`` appearing in the output SMILES at that location is a result of both the ``[Branch1]`` token at position 3 and the ``[P]`` token at index 5. This works for both encoding and decoding. For finer control of tracking the translation (like tracking rings), you can access attributions in the underlying molecular graph with ``get_attribution``.
-
+``attr`` is a list of `AttributionMap`s containing the output token, its index, and input tokens that led to it. For example, the ``P`` appearing in the output SMILES at that location is a result of both the ``[Branch1]`` token at position 3 and the ``[P]`` token at index 5. This works for both encoding and decoding. For finer control of tracking the translation (like tracking rings), you can access attributions in the underlying molecular graph with ``get_attribution``.
 
 ### More Usages and Examples
 

--- a/selfies/decoder.py
+++ b/selfies/decoder.py
@@ -12,7 +12,7 @@ from selfies.grammar_rules import (
     process_branch_symbol,
     process_ring_symbol
 )
-from selfies.mol_graph import MolecularGraph
+from selfies.mol_graph import MolecularGraph, Attribution
 from selfies.utils.selfies_utils import split_selfies
 from selfies.utils.smiles_utils import mol_to_smiles
 
@@ -123,7 +123,8 @@ def _derive_mol_from_symbols(
                     symbol_iter, mol, selfies, (Q + 1),
                     init_state=binit_state, root_atom=prev_atom, rings=rings,
                     _attribute_stack=_attribute_stack +
-                    [(index, symbol)] if _attribute_stack is not None else None
+                    [Attribution(index, symbol)
+                     ] if _attribute_stack is not None else None
                 )
 
         # Case 2: Ring symbol (e.g. [Ring2])
@@ -163,18 +164,18 @@ def _derive_mol_from_symbols(
                 if state == 0:
                     o = mol.add_atom(atom, True)
                     mol.add_attribution(
-                        o,  _attribute_stack + [(index, symbol)]
+                        o,  _attribute_stack + [Attribution(index, symbol)]
                         if _attribute_stack is not None else None)
             else:
                 o = mol.add_atom(atom)
                 mol.add_attribution(
-                    o, _attribute_stack + [(index, symbol)]
+                    o, _attribute_stack + [Attribution(index, symbol)]
                     if _attribute_stack is not None else None)
                 src, dst = prev_atom.index, atom.index
                 o = mol.add_bond(src=src, dst=dst,
                                  order=bond_order, stereo=stereo)
                 mol.add_attribution(
-                    o, _attribute_stack + [(index, symbol)]
+                    o, _attribute_stack + [Attribution(index, symbol)]
                     if _attribute_stack is not None else None)
             prev_atom = atom
 

--- a/selfies/encoder.py
+++ b/selfies/encoder.py
@@ -139,7 +139,7 @@ def _should_invert_chirality(mol, atom):
     return count % 2 != 0  # if odd permutation, should invert chirality
 
 
-def _fragment_to_selfies(mol, bond_into_root, root, attribution_maps):
+def _fragment_to_selfies(mol, bond_into_root, root, attribution_maps, index_offset=0):
     derived = []
 
     bond_into_curr, curr = bond_into_root, root
@@ -148,7 +148,7 @@ def _fragment_to_selfies(mol, bond_into_root, root, attribution_maps):
         token = _atom_to_selfies(bond_into_curr, curr_atom)
         derived.append(token)
         attribution_maps.append(AttributionMap(
-            len(derived) - 1, token, mol.get_attribution(curr_atom)))
+            len(derived) - 1 + index_offset, token, mol.get_attribution(curr_atom)))
 
         out_bonds = mol.get_out_dirbonds(curr)
         for i, bond in enumerate(out_bonds):
@@ -167,18 +167,18 @@ def _fragment_to_selfies(mol, bond_into_root, root, attribution_maps):
 
                 derived.append(ring_symbol)
                 attribution_maps.append(AttributionMap(
-                    len(derived) - 1, ring_symbol, mol.get_attribution(bond)))
+                    len(derived) - 1 + index_offset, ring_symbol, mol.get_attribution(bond)))
                 for symbol in Q_as_symbols:
                     derived.append(symbol)
                     attribution_maps.append(AttributionMap(
-                        len(derived) - 1, symbol, mol.get_attribution(bond)))
+                        len(derived) - 1 + index_offset, symbol, mol.get_attribution(bond)))
 
             elif i == len(out_bonds) - 1:
                 bond_into_curr, curr = bond, bond.dst
 
             else:
                 branch = _fragment_to_selfies(
-                    mol, bond, bond.dst, attribution_maps)
+                    mol, bond, bond.dst, attribution_maps, len(derived))
                 Q_as_symbols = get_selfies_from_index(len(branch) - 1)
                 branch_symbol = "[{}Branch{}]".format(
                     _bond_to_selfies(bond, show_stereo=False),
@@ -187,11 +187,11 @@ def _fragment_to_selfies(mol, bond_into_root, root, attribution_maps):
 
                 derived.append(branch_symbol)
                 attribution_maps.append(AttributionMap(
-                    len(derived) - 1, branch_symbol, mol.get_attribution(bond)))
+                    len(derived) - 1 + index_offset, branch_symbol, mol.get_attribution(bond)))
                 for symbol in Q_as_symbols:
                     derived.append(symbol)
                     attribution_maps.append(AttributionMap(
-                        len(derived) - 1, symbol, mol.get_attribution(bond)))
+                        len(derived) - 1 + index_offset, symbol, mol.get_attribution(bond)))
                 derived.extend(branch)
 
         # end of chain

--- a/selfies/encoder.py
+++ b/selfies/encoder.py
@@ -141,7 +141,8 @@ def _should_invert_chirality(mol, atom):
     return count % 2 != 0  # if odd permutation, should invert chirality
 
 
-def _fragment_to_selfies(mol, bond_into_root, root, attribution_maps, attribution_index=0):
+def _fragment_to_selfies(mol, bond_into_root, root,
+                         attribution_maps, attribution_index=0):
     derived = []
 
     bond_into_curr, curr = bond_into_root, root
@@ -151,7 +152,8 @@ def _fragment_to_selfies(mol, bond_into_root, root, attribution_maps, attributio
         derived.append(token)
 
         attribution_maps.append(AttributionMap(
-            len(derived) - 1 + attribution_index, token, mol.get_attribution(curr_atom)))
+            len(derived) - 1 + attribution_index,
+            token, mol.get_attribution(curr_atom)))
 
         out_bonds = mol.get_out_dirbonds(curr)
         for i, bond in enumerate(out_bonds):
@@ -170,11 +172,13 @@ def _fragment_to_selfies(mol, bond_into_root, root, attribution_maps, attributio
 
                 derived.append(ring_symbol)
                 attribution_maps.append(AttributionMap(
-                    len(derived) - 1 + attribution_index, ring_symbol, mol.get_attribution(bond)))
+                    len(derived) - 1 + attribution_index,
+                    ring_symbol, mol.get_attribution(bond)))
                 for symbol in Q_as_symbols:
                     derived.append(symbol)
                     attribution_maps.append(AttributionMap(
-                        len(derived) - 1 + attribution_index, symbol, mol.get_attribution(bond)))
+                        len(derived) - 1 + attribution_index,
+                        symbol, mol.get_attribution(bond)))
 
             elif i == len(out_bonds) - 1:
                 bond_into_curr, curr = bond, bond.dst
@@ -190,11 +194,13 @@ def _fragment_to_selfies(mol, bond_into_root, root, attribution_maps, attributio
 
                 derived.append(branch_symbol)
                 attribution_maps.append(AttributionMap(
-                    len(derived) - 1 + attribution_index, branch_symbol, mol.get_attribution(bond)))
+                    len(derived) - 1 + attribution_index,
+                    branch_symbol, mol.get_attribution(bond)))
                 for symbol in Q_as_symbols:
                     derived.append(symbol)
                     attribution_maps.append(AttributionMap(
-                        len(derived) - 1 + attribution_index, symbol, mol.get_attribution(bond)))
+                        len(derived) - 1 + attribution_index,
+                        symbol, mol.get_attribution(bond)))
                 derived.extend(branch)
 
         # end of chain

--- a/selfies/mol_graph.py
+++ b/selfies/mol_graph.py
@@ -1,6 +1,6 @@
 import functools
 import itertools
-from typing import List, Optional, Union, Tuple
+from typing import List, Optional, Union
 from dataclasses import dataclass, field
 
 from selfies.bond_constraints import get_bonding_capacity
@@ -20,7 +20,8 @@ class Attribution:
 
 @dataclass
 class AttributionMap:
-    """A mapping from input to single output token showing which input tokens created the output token.
+    """A mapping from input to single output token showing which
+    input tokens created the output token.
     """
     #: Index of output token
     index: int

--- a/selfies/mol_graph.py
+++ b/selfies/mol_graph.py
@@ -10,16 +10,23 @@ from selfies.utils.matching_utils import find_perfect_matching
 
 @dataclass
 class Attribution:
+    """A dataclass that contains token string and its index.
+    """
+    #: token index
     index: int
+    #: token string
     token: str
 
 
 @dataclass
 class AttributionMap:
-    """A mapping from input to output token showing which input tokens created the output token.
+    """A mapping from input to single output token showing which input tokens created the output token.
     """
+    #: Index of output token
     index: int
+    #: Output token
     token: str
+    #: List of input tokens that created the output token
     attribution: List[Attribution] = field(default_factory=list)
 
 
@@ -153,7 +160,10 @@ class MolecularGraph:
             attr: List[Attribution]
     ) -> None:
         if self._attributable:
-            self._attribution[o] = attr
+            if o in self._attribution:
+                self._attribution[o].extend(attr)
+            else:
+                self._attribution[o] = attr
 
     def add_bond(
             self, src: int, dst: int,

--- a/selfies/mol_graph.py
+++ b/selfies/mol_graph.py
@@ -1,10 +1,26 @@
 import functools
 import itertools
 from typing import List, Optional, Union, Tuple
+from dataclasses import dataclass, field
 
 from selfies.bond_constraints import get_bonding_capacity
 from selfies.constants import AROMATIC_VALENCES
 from selfies.utils.matching_utils import find_perfect_matching
+
+
+@dataclass
+class Attribution:
+    index: int
+    token: str
+
+
+@dataclass
+class AttributionMap:
+    """A mapping from input to output token showing which input tokens created the output token.
+    """
+    index: int
+    token: str
+    attribution: List[Attribution] = field(default_factory=list)
 
 
 class Atom:
@@ -95,7 +111,7 @@ class MolecularGraph:
     def get_attribution(
         self,
         o: Union[DirectedBond, Atom]
-    ) -> List[Tuple[int, str]]:
+    ) -> List[Attribution]:
         if self._attributable and o in self._attribution:
             return self._attribution[o]
         return None
@@ -134,7 +150,7 @@ class MolecularGraph:
     def add_attribution(
             self,
             o: Union[DirectedBond, Atom],
-            attr: List[Tuple[int, str]]
+            attr: List[Attribution]
     ) -> None:
         if self._attributable:
             self._attribution[o] = attr

--- a/selfies/utils/smiles_utils.py
+++ b/selfies/utils/smiles_utils.py
@@ -5,7 +5,8 @@ from typing import Iterator, Optional, Tuple, Union, List
 
 from selfies.constants import AROMATIC_SUBSET, ELEMENTS, ORGANIC_SUBSET
 from selfies.exceptions import SMILESParserError
-from selfies.mol_graph import Atom, Attribution, AttributionMap, DirectedBond, MolecularGraph
+from selfies.mol_graph import Atom, Attribution, \
+    AttributionMap, DirectedBond, MolecularGraph
 
 SMILES_BRACKETED_ATOM_PATTERN = re.compile(
     r"^[\[]"  # opening square bracket [
@@ -441,7 +442,8 @@ def _derive_smiles_from_fragment(
     token = atom_to_smiles(curr_atom)
     derived.append(token)
     attribution_maps.append(AttributionMap(
-        len(derived) - 1 + attribution_index, token, mol.get_attribution(curr_atom)))
+        len(derived) - 1 + attribution_index,
+        token, mol.get_attribution(curr_atom)))
 
     out_bonds = mol.get_out_dirbonds(curr)
     for i, bond in enumerate(out_bonds):
@@ -449,7 +451,8 @@ def _derive_smiles_from_fragment(
             token = bond_to_smiles(bond)
             derived.append(token)
             attribution_maps.append(AttributionMap(
-                len(derived) - 1 + attribution_index, token, mol.get_attribution(bond)))
+                len(derived) - 1 + attribution_index,
+                token, mol.get_attribution(bond)))
             ends = (min(bond.src, bond.dst), max(bond.src, bond.dst))
             rnum = ring_log.setdefault(ends, len(ring_log) + 1)
             if rnum >= 10:
@@ -463,9 +466,11 @@ def _derive_smiles_from_fragment(
             token = bond_to_smiles(bond)
             derived.append(token)
             attribution_maps.append(AttributionMap(
-                len(derived) - 1 + attribution_index, token, mol.get_attribution(bond)))
+                len(derived) - 1 + attribution_index,
+                token, mol.get_attribution(bond)))
             _derive_smiles_from_fragment(
-                derived, mol, bond.dst, ring_log, attribution_maps, attribution_index)
+                derived, mol, bond.dst, ring_log,
+                attribution_maps, attribution_index)
             if i < len(out_bonds) - 1:
                 derived.append(")")
     return attribution_maps

--- a/tests/test_selfies.py
+++ b/tests/test_selfies.py
@@ -157,4 +157,5 @@ def test_encoder_attribution():
                 f'found {ta[1]}; should be {indices[i]}'
         if ta.token == '[Cl]':
             assert 'Cl' in [
-                a.token for a in ta.attribution], 'Failed to find Cl in attribution map'
+                a.token for a in ta.attribution],\
+                'Failed to find Cl in attribution map'

--- a/tests/test_selfies.py
+++ b/tests/test_selfies.py
@@ -140,9 +140,9 @@ def test_decoder_attribution():
         "[C][N][C][Branch1][C][P][C][C][Ring1][=Branch1]", attribute=True)
     # check that P lined up
     for ta in am:
-        if ta[0] == 'P':
-            for i, v in ta[1]:
-                if v == '[P]':
+        if ta.token == 'P':
+            for a in ta.attribution:
+                if a.token == '[P]':
                     return
     raise ValueError('Failed to find P in attribution map')
 
@@ -151,13 +151,10 @@ def test_encoder_attribution():
     smiles = "C1([O-])C=CC=C1Cl"
     indices = [0, 3, 3, 3, 5, 7, 8, 10, None, None, 12]
     s, am = sf.encoder(smiles, attribute=True)
-    # check that Cl lined up
     for i, ta in enumerate(am):
-        if ta[1]:
-            assert indices[i] == ta[1][0][0], \
+        if ta.attribution:
+            assert indices[i] == ta.attribution[0].index, \
                 f'found {ta[1]}; should be {indices[i]}'
-        if ta[0] == '[Cl]':
-            for i, v in ta[1]:
-                if v == 'Cl':
-                    return
-    raise ValueError('Failed to find Cl in attribution map')
+        if ta.token == '[Cl]':
+            assert 'Cl' in [
+                a.token for a in ta.attribution], 'Failed to find Cl in attribution map'


### PR DESCRIPTION
Following discussion from #79, #75, and #78 I've revised the attribution map to track both input and output token indices. As this made the attributions get a bit complicated, I added two dataclasses `Attribution` and `AttributionMap` to help make it clear what the meaning is of the various elements of the attribution. One (maybe) disadvantage is that it can be hard to know what the `index` means because it comes from the tokenizer within the library. One possible change would be to make index be strictly ascending or switch to string index. 

Here are examples:

## Encoder 

```python
s, am = sf.encoder('C1([O-])C=CC=C1Cl.CCO', attribute=True)
print(s)
for a in am:
    print(a)
```

```python
[C][Branch1][C][O-1][C][=C][C][=C][Ring1][=Branch1][Cl].[C][C][O]
AttributionMap(index=0, token='[C]', attribution=[Attribution(index=0, token='C')])
AttributionMap(index=1, token='[O-1]', attribution=[Attribution(index=3, token='[O-]')])
AttributionMap(index=1, token='[Branch1]', attribution=[Attribution(index=3, token='[O-]')])
AttributionMap(index=2, token='[C]', attribution=[Attribution(index=3, token='[O-]')])
AttributionMap(index=4, token='[C]', attribution=[Attribution(index=5, token='C')])
AttributionMap(index=5, token='[=C]', attribution=[Attribution(index=7, token='C')])
AttributionMap(index=6, token='[C]', attribution=[Attribution(index=8, token='C')])
AttributionMap(index=7, token='[=C]', attribution=[Attribution(index=10, token='C')])
AttributionMap(index=8, token='[Ring1]', attribution=None)
AttributionMap(index=9, token='[=Branch1]', attribution=None)
AttributionMap(index=10, token='[Cl]', attribution=[Attribution(index=12, token='Cl')])
AttributionMap(index=11, token='[C]', attribution=[Attribution(index=13, token='C')])
AttributionMap(index=12, token='[C]', attribution=[Attribution(index=14, token='C')])
AttributionMap(index=13, token='[O]', attribution=[Attribution(index=15, token='O')])
```

## Decoder

```python
s, am = sf.decoder('[C][Branch1][C][O-1][C][=C][C][=C][Ring1][=Branch1][Cl]', attribute=True)
print(s)
for a in am:
    print(a)
```

```python
C1([O-1])C=CC=C1Cl.CCO
AttributionMap(index=0, token='C', attribution=[Attribution(index=0, token='[C]')])
AttributionMap(index=5, token='[O-1]', attribution=[Attribution(index=1, token='[Branch1]'), Attribution(index=3, token='[O-1]')])
AttributionMap(index=8, token='C', attribution=[Attribution(index=4, token='[C]')])
AttributionMap(index=9, token='=', attribution=[Attribution(index=5, token='[=C]')])
AttributionMap(index=10, token='C', attribution=[Attribution(index=5, token='[=C]')])
AttributionMap(index=12, token='C', attribution=[Attribution(index=6, token='[C]')])
AttributionMap(index=13, token='=', attribution=[Attribution(index=7, token='[=C]')])
AttributionMap(index=14, token='C', attribution=[Attribution(index=7, token='[=C]')])
AttributionMap(index=18, token='Cl', attribution=[Attribution(index=10, token='[Cl]')])
AttributionMap(index=19, token='C', attribution=[Attribution(index=11, token='[C]')])
AttributionMap(index=21, token='C', attribution=[Attribution(index=12, token='[C]')])
AttributionMap(index=23, token='O', attribution=[Attribution(index=13, token='[O]')])
```