### PR TITLE
Standardized python versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## v2.1.0 - [to be announced shortly]
 
+### Changed:
+- Dropped support for Python 3.5-3.6 and will continue to support only current Python versions.
+
 ### Added:
 - optional attribution to map encoder/decoder output string back to input string (Issue #48)
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="selfies",
-    version="2.0.0",
+    version="2.1.0",
     author="Mario Krenn, Alston Lo, and many other contributors",
     author_email="mario.krenn@utoronto.ca, alan@aspuru.com",
     description="SELFIES (SELF-referencIng Embedded Strings) is a "
@@ -19,13 +19,13 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     classifiers=[
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3 :: Only",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
     ],
-    python_requires='>=3.5'
+    python_requires='>=3.7'
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,lint
+envlist = py37,py38,py39,py310,lint
 requires = tox-conda
 
 [testenv]
@@ -7,7 +7,7 @@ setenv =
     CONDA_DLL_SEARCH_MODIFICATION_ENABLE = 1
 whitelist_externals = python
 
-[testenv:py36]
+[testenv:py{37,38,39,310}]
 conda_deps =
     pytest
     rdkit


### PR DESCRIPTION
Addresses issue #85. Set python version to be 3.7-3.10 in tox and `setup.py`