### PR TITLE
Fixed index counting bug in attribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v2.1.1 - TBD
+- Fixed index bug in attribution 
+
 ## v2.1.0 - 17.05.2022
 
 ### Changed:

--- a/README.md
+++ b/README.md
@@ -168,11 +168,11 @@ SELFIES [C][N][C][Branch1][C][P][C][C][Ring1][=Branch1]
 SMILES C1NC(P)CC1
 Attribution:
 AttributionMap(index=0, token='C', attribution=[Attribution(index=0, token='[C]')])
-AttributionMap(index=4, token='N', attribution=[Attribution(index=1, token='[N]')])
-AttributionMap(index=6, token='C', attribution=[Attribution(index=2, token='[C]')])
-AttributionMap(index=9, token='P', attribution=[Attribution(index=3, token='[Branch1]'), Attribution(index=5, token='[P]')])
-AttributionMap(index=12, token='C', attribution=[Attribution(index=6, token='[C]')])
-AttributionMap(index=14, token='C', attribution=[Attribution(index=7, token='[C]')])
+AttributionMap(index=2, token='N', attribution=[Attribution(index=1, token='[N]')])
+AttributionMap(index=3, token='C', attribution=[Attribution(index=2, token='[C]')])
+AttributionMap(index=5, token='P', attribution=[Attribution(index=3, token='[Branch1]'), Attribution(index=5, token='[P]')])
+AttributionMap(index=7, token='C', attribution=[Attribution(index=6, token='[C]')])
+AttributionMap(index=8, token='C', attribution=[Attribution(index=7, token='[C]')])
 ```
 
 ``attr`` is a list of `AttributionMap`s containing the output token, its index, and input tokens that led to it. For example, the ``P`` appearing in the output SMILES at that location is a result of both the ``[Branch1]`` token at position 3 and the ``[P]`` token at index 5. This works for both encoding and decoding. For finer control of tracking the translation (like tracking rings), you can access attributions in the underlying molecular graph with ``get_attribution``.

--- a/selfies/encoder.py
+++ b/selfies/encoder.py
@@ -184,6 +184,10 @@ def _fragment_to_selfies(mol, bond_into_root, root,
                 bond_into_curr, curr = bond, bond.dst
 
             else:
+                # start, end are so we can go back and
+                # correct offset from branch symbol in
+                # branch tokens
+                start = len(attribution_maps)
                 branch = _fragment_to_selfies(
                     mol, bond, bond.dst, attribution_maps, len(derived))
                 Q_as_symbols = get_selfies_from_index(len(branch) - 1)
@@ -191,22 +195,26 @@ def _fragment_to_selfies(mol, bond_into_root, root,
                     _bond_to_selfies(bond, show_stereo=False),
                     len(Q_as_symbols)
                 )
-
-                derived.append(branch_symbol)
-                attribution_maps.append(AttributionMap(
-                    len(derived) - 1 + attribution_index,
-                    branch_symbol, mol.get_attribution(bond)))
+                end = len(attribution_maps)
                 for symbol in Q_as_symbols:
                     derived.append(symbol)
                     attribution_maps.append(AttributionMap(
                         len(derived) - 1 + attribution_index,
                         symbol, mol.get_attribution(bond)))
+
+                # account for branch symbol because it is inserted after
+                for i in range(start, end):
+                    attribution_maps[i].index += len(Q_as_symbols) + 1
+                derived.append(branch_symbol)
+                attribution_maps.append(AttributionMap(
+                    len(derived) - 1 + attribution_index,
+                    branch_symbol, mol.get_attribution(bond)))
+
                 derived.extend(branch)
 
         # end of chain
         if (not out_bonds) or out_bonds[-1].ring_bond:
             break
-
     return derived
 
 

--- a/selfies/encoder.py
+++ b/selfies/encoder.py
@@ -196,6 +196,8 @@ def _fragment_to_selfies(mol, bond_into_root, root,
                     len(Q_as_symbols)
                 )
                 end = len(attribution_maps)
+
+                derived.append(branch_symbol)
                 for symbol in Q_as_symbols:
                     derived.append(symbol)
                     attribution_maps.append(AttributionMap(
@@ -203,9 +205,8 @@ def _fragment_to_selfies(mol, bond_into_root, root,
                         symbol, mol.get_attribution(bond)))
 
                 # account for branch symbol because it is inserted after
-                for i in range(start, end):
-                    attribution_maps[i].index += len(Q_as_symbols) + 1
-                derived.append(branch_symbol)
+                for j in range(start, end):
+                    attribution_maps[j].index += len(Q_as_symbols) + 1
                 attribution_maps.append(AttributionMap(
                     len(derived) - 1 + attribution_index,
                     branch_symbol, mol.get_attribution(bond)))

--- a/selfies/utils/smiles_utils.py
+++ b/selfies/utils/smiles_utils.py
@@ -424,12 +424,16 @@ def mol_to_smiles(
         derived = []
         _derive_smiles_from_fragment(
             derived, mol, root, ring_log, attribution_maps, attribution_index)
-        attribution_index += len(derived)
+        attribution_index += _strlen(derived)
         fragments.append("".join(derived))
     # trim attribution map of empty tokens
     attribution_maps = [a for a in attribution_maps if a.token]
     result = ".".join(fragments), attribution_maps
     return result if attribute else result[0]
+
+
+def _strlen(slist: List[str]) -> int:
+    return len(''.join(slist))
 
 
 def _derive_smiles_from_fragment(
@@ -442,7 +446,7 @@ def _derive_smiles_from_fragment(
     token = atom_to_smiles(curr_atom)
     derived.append(token)
     attribution_maps.append(AttributionMap(
-        len(derived) - 1 + attribution_index,
+        _strlen(derived) - 1 + attribution_index,
         token, mol.get_attribution(curr_atom)))
 
     out_bonds = mol.get_out_dirbonds(curr)
@@ -451,7 +455,7 @@ def _derive_smiles_from_fragment(
             token = bond_to_smiles(bond)
             derived.append(token)
             attribution_maps.append(AttributionMap(
-                len(derived) - 1 + attribution_index,
+                _strlen(derived) - 1 + attribution_index,
                 token, mol.get_attribution(bond)))
             ends = (min(bond.src, bond.dst), max(bond.src, bond.dst))
             rnum = ring_log.setdefault(ends, len(ring_log) + 1)
@@ -466,7 +470,7 @@ def _derive_smiles_from_fragment(
             token = bond_to_smiles(bond)
             derived.append(token)
             attribution_maps.append(AttributionMap(
-                len(derived) - 1 + attribution_index,
+                _strlen(derived) - 1 + attribution_index,
                 token, mol.get_attribution(bond)))
             _derive_smiles_from_fragment(
                 derived, mol, bond.dst, ring_log,

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="selfies",
-    version="2.1.0",
+    version="2.1.1",
     author="Mario Krenn, Alston Lo, and many other contributors",
     author_email="mario.krenn@utoronto.ca, alan@aspuru.com",
     description="SELFIES (SELF-referencIng Embedded Strings) is a "


### PR DESCRIPTION
I've revised the indexing added in 2.1.0 to follow SMILES string index exactly and SELFIES token index exactly. Previously it used the current length of the SMILES string list which could contain empty elements. In SELFIES, it incorrectly treated order of index. This PR also increments version/updates changelog. 

New behavior:

```py
SELFIES [C][N][C][Branch1][C][P][C][C][Ring1][=Branch1]
SMILES C1NC(P)CC1
Attribution:
AttributionMap(index=0, token='C', attribution=[Attribution(index=0, token='[C]')])
AttributionMap(index=2, token='N', attribution=[Attribution(index=1, token='[N]')])
AttributionMap(index=3, token='C', attribution=[Attribution(index=2, token='[C]')])
AttributionMap(index=5, token='P', attribution=[Attribution(index=3, token='[Branch1]'), Attribution(index=5, token='[P]')])
AttributionMap(index=7, token='C', attribution=[Attribution(index=6, token='[C]')])
AttributionMap(index=8, token='C', attribution=[Attribution(index=7, token='[C]')])
SELFIES [C][N][C][C][Branch1][P][C][C][Ring1][=Branch1]
SMILES C1NC(P)CC1
Attribution:
AttributionMap(index=0, token='[C]', attribution=[Attribution(index=0, token='C')])
AttributionMap(index=1, token='[N]', attribution=[Attribution(index=2, token='N')])
AttributionMap(index=2, token='[C]', attribution=[Attribution(index=3, token='C')])
AttributionMap(index=5, token='[P]', attribution=[Attribution(index=5, token='P')])
AttributionMap(index=3, token='[C]', attribution=[Attribution(index=5, token='P')])
AttributionMap(index=4, token='[Branch1]', attribution=[Attribution(index=5, token='P')])
AttributionMap(index=6, token='[C]', attribution=[Attribution(index=7, token='C')])
AttributionMap(index=7, token='[C]', attribution=[Attribution(index=8, token='C')])
AttributionMap(index=8, token='[Ring1]', attribution=None)
AttributionMap(index=9, token='[=Branch1]', attribution=None)
```