### PR TITLE
fix #104 Add check for dot symbol and warn user

### DIFF
--- a/selfies/utils/encoding_utils.py
+++ b/selfies/utils/encoding_utils.py
@@ -47,17 +47,20 @@ def selfies_to_encoding(
         selfies += "[nop]" * (pad_to_len - len_selfies(selfies))
 
     # integer encode
-    char_list = list(split_selfies(selfies))
+    char_list = split_selfies(selfies)
 
-    # Check if SELFIES string contains unconnected molecules
-    if "." in list(char_list) and not "." in vocab_stoi:
-        raise ValueError(
-            "The SELFIES string contains two unconnected molecules "
-            "(given by the '.' character), but vocab_stoi does not "
-            "contain the '.' key. Please add it or separate the molecules."
-        )
-
-    integer_encoded = [vocab_stoi[char] for char in char_list]
+    try:
+        integer_encoded = [vocab_stoi[char] for char in char_list]
+    except KeyError as e:
+        if e.args[0] == ".":
+            raise KeyError(
+                "The SELFIES string contains two unconnected molecules "
+                "(given by the '.' character), but vocab_stoi does not "
+                "contain the '.' key. Please add it to the vocabulary "
+                "or separate the molecules."
+            )
+        raise KeyError(e.args[0])
+        
 
     if enc_type == "label":
         return integer_encoded

--- a/selfies/utils/encoding_utils.py
+++ b/selfies/utils/encoding_utils.py
@@ -47,21 +47,18 @@ def selfies_to_encoding(
         selfies += "[nop]" * (pad_to_len - len_selfies(selfies))
 
     # integer encode
-    char_list = split_selfies(selfies)
-
-    try:
-        integer_encoded = [vocab_stoi[char] for char in char_list]
-    except KeyError as e:
-        if e.args[0] == ".":
+    integer_encoded = []
+    for char in split_selfies(selfies):
+        if (char == ".") and ("." not in vocab_stoi):
             raise KeyError(
                 "The SELFIES string contains two unconnected molecules "
                 "(given by the '.' character), but vocab_stoi does not "
                 "contain the '.' key. Please add it to the vocabulary "
                 "or separate the molecules."
             )
-        raise KeyError(e.args[0])
-        
 
+        integer_encoded.append(vocab_stoi[char])
+        
     if enc_type == "label":
         return integer_encoded
 

--- a/selfies/utils/encoding_utils.py
+++ b/selfies/utils/encoding_utils.py
@@ -47,7 +47,16 @@ def selfies_to_encoding(
         selfies += "[nop]" * (pad_to_len - len_selfies(selfies))
 
     # integer encode
-    char_list = split_selfies(selfies)
+    char_list = list(split_selfies(selfies))
+
+    # Check if SELFIES string contains unconnected molecules
+    if "." in list(char_list) and not "." in vocab_stoi:
+        raise ValueError(
+            "The SELFIES string contains two unconnected molecules "
+            "(given by the '.' character), but vocab_stoi does not "
+            "contain the '.' key. Please add it or separate the molecules."
+        )
+
     integer_encoded = [vocab_stoi[char] for char in char_list]
 
     if enc_type == "label":


### PR DESCRIPTION
When using the results of the SELFIES library for an ML model, I encountered some issues while preparing the data for training. If one uses the `get_alphabet_from_selfies` to generate a list of tokens, and then encodes each input according to it using `selfies_to_encoding`, it is possible to get a ValueKey error for the dot symbol. More details in #104.

This can be a bit unintuitive, as the key error can result from using the vocabulary generated from the same dataset that is fed to the encoding function.

With this pull request, I suggest adding a more descriptive error for this case, which could help users that are not very knowledgeable in chemistry understand what can be done.