### PR TITLE
Replace recursion with stack (fix #115)

### DIFF
--- a/tests/test_specific_cases.py
+++ b/tests/test_specific_cases.py
@@ -329,3 +329,12 @@ def test_old_symbols():
         sf.decoder(long_s, compatible=True)
     except Exception:
         assert False
+
+def test_large_selfies_decoding():
+    """Test that we can decode extremely large SELFIES strings (used to cause a RecursionError)
+    """
+
+    large_selfies = "[C]" * 1024
+    expected_smiles = "C" * 1024
+
+    assert decode_eq(large_selfies, expected_smiles)


### PR DESCRIPTION
Changed `_derive_smiles_from_fragment` to use a stack rather than recursion as #115 is triggered by hitting the stack limit. 

Test suite passed and to verify further I compared the encodings AND decodings of every smile in the test set csv's with and without this change (there were no differences).

Closes #115.

Edit: test suite passed up to the linting errors, which do not seem to be new.